### PR TITLE
#12   secure link sharing

### DIFF
--- a/secure-vault/drizzle/0004_next_pestilence.sql
+++ b/secure-vault/drizzle/0004_next_pestilence.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `share_links` MODIFY COLUMN `expires_at` timestamp;--> statement-breakpoint
+ALTER TABLE `share_link_access_logs` ADD `email` varchar(255);--> statement-breakpoint
+ALTER TABLE `share_link_otps` ADD `email` varchar(255) NOT NULL;--> statement-breakpoint
+ALTER TABLE `share_link_otps` ADD `attempt_count` int DEFAULT 0 NOT NULL;--> statement-breakpoint
+CREATE INDEX `idx_share_links_folder_id` ON `share_links` (`folder_id`);

--- a/secure-vault/drizzle/meta/0004_snapshot.json
+++ b/secure-vault/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,1641 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "f065d37e-78d8-430b-99a9-566f71a65b10",
+  "prevId": "02f26bdf-7b04-4253-8e87-ecc990b34213",
+  "tables": {
+    "email_verification_tokens": {
+      "name": "email_verification_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "idx_email_verification_tokens_user_id": {
+          "name": "idx_email_verification_tokens_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "email_verification_tokens_user_id_users_id_fk": {
+          "name": "email_verification_tokens_user_id_users_id_fk",
+          "tableFrom": "email_verification_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "email_verification_tokens_id": {
+          "name": "email_verification_tokens_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "idx_password_reset_tokens_user_id": {
+          "name": "idx_password_reset_tokens_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "password_reset_tokens_id": {
+          "name": "password_reset_tokens_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "embedding_chunks": {
+      "name": "embedding_chunks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "modality": {
+          "name": "modality",
+          "type": "enum('pdf','image')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pdf'"
+        },
+        "page_from": {
+          "name": "page_from",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "page_to": {
+          "name": "page_to",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "char_count": {
+          "name": "char_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "encrypted_text": {
+          "name": "encrypted_text",
+          "type": "longblob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text_iv": {
+          "name": "text_iv",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text_auth_tag": {
+          "name": "text_auth_tag",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_embedding_chunks_job_chunk": {
+          "name": "uq_embedding_chunks_job_chunk",
+          "columns": [
+            "job_id",
+            "chunk_index"
+          ],
+          "isUnique": true
+        },
+        "idx_embedding_chunks_file_id": {
+          "name": "idx_embedding_chunks_file_id",
+          "columns": [
+            "file_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "embedding_chunks_job_id_embedding_jobs_id_fk": {
+          "name": "embedding_chunks_job_id_embedding_jobs_id_fk",
+          "tableFrom": "embedding_chunks",
+          "tableTo": "embedding_jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "embedding_chunks_file_id_files_id_fk": {
+          "name": "embedding_chunks_file_id_files_id_fk",
+          "tableFrom": "embedding_chunks",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "embedding_chunks_id": {
+          "name": "embedding_chunks_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "embedding_jobs": {
+      "name": "embedding_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('queued','processing','ready','skipped','failed')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "modality": {
+          "name": "modality",
+          "type": "enum('pdf','image')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pdf'"
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding_dimensions": {
+          "name": "embedding_dimensions",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1536
+        },
+        "ocr_provider": {
+          "name": "ocr_provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "uq_embedding_jobs_file_modality": {
+          "name": "uq_embedding_jobs_file_modality",
+          "columns": [
+            "file_id",
+            "modality"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "embedding_jobs_file_id_files_id_fk": {
+          "name": "embedding_jobs_file_id_files_id_fk",
+          "tableFrom": "embedding_jobs",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "embedding_jobs_triggered_by_users_id_fk": {
+          "name": "embedding_jobs_triggered_by_users_id_fk",
+          "tableFrom": "embedding_jobs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triggered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "embedding_jobs_id": {
+          "name": "embedding_jobs_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "file_chunks": {
+      "name": "file_chunks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iv": {
+          "name": "iv",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_file_chunks_file_chunk": {
+          "name": "uq_file_chunks_file_chunk",
+          "columns": [
+            "file_id",
+            "chunk_index"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "file_chunks_file_id_files_id_fk": {
+          "name": "file_chunks_file_id_files_id_fk",
+          "tableFrom": "file_chunks",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "file_chunks_id": {
+          "name": "file_chunks_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "file_versions": {
+      "name": "file_versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_chunks": {
+          "name": "total_chunks",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_fek": {
+          "name": "encrypted_fek",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "uq_file_versions_file_version": {
+          "name": "uq_file_versions_file_version",
+          "columns": [
+            "file_id",
+            "version_number"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "file_versions_file_id_files_id_fk": {
+          "name": "file_versions_file_id_files_id_fk",
+          "tableFrom": "file_versions",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "file_versions_id": {
+          "name": "file_versions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "files": {
+      "name": "files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_chunks": {
+          "name": "total_chunks",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_fek": {
+          "name": "encrypted_fek",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('uploading','ready','failed')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'uploading'"
+        },
+        "has_thumbnail": {
+          "name": "has_thumbnail",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "thumbnail_r2_key": {
+          "name": "thumbnail_r2_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "idx_files_folder_id": {
+          "name": "idx_files_folder_id",
+          "columns": [
+            "folder_id"
+          ],
+          "isUnique": false
+        },
+        "idx_files_user_folder": {
+          "name": "idx_files_user_folder",
+          "columns": [
+            "user_id",
+            "folder_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "files_user_id_users_id_fk": {
+          "name": "files_user_id_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "files_folder_id_folders_id_fk": {
+          "name": "files_folder_id_folders_id_fk",
+          "tableFrom": "files",
+          "tableTo": "folders",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "files_id": {
+          "name": "files_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "folders": {
+      "name": "folders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "folders_user_id_users_id_fk": {
+          "name": "folders_user_id_users_id_fk",
+          "tableFrom": "folders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "folders_parent_id_folders_id_fk": {
+          "name": "folders_parent_id_folders_id_fk",
+          "tableFrom": "folders",
+          "tableTo": "folders",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "folders_id": {
+          "name": "folders_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "share_link_access_logs": {
+      "name": "share_link_access_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accessed_at": {
+          "name": "accessed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "idx_access_logs_link_id": {
+          "name": "idx_access_logs_link_id",
+          "columns": [
+            "link_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "share_link_access_logs_link_id_share_links_id_fk": {
+          "name": "share_link_access_logs_link_id_share_links_id_fk",
+          "tableFrom": "share_link_access_logs",
+          "tableTo": "share_links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "share_link_access_logs_id": {
+          "name": "share_link_access_logs_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "share_link_emails": {
+      "name": "share_link_emails",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "share_link_emails_link_id_share_links_id_fk": {
+          "name": "share_link_emails_link_id_share_links_id_fk",
+          "tableFrom": "share_link_emails",
+          "tableTo": "share_links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "share_link_emails_id": {
+          "name": "share_link_emails_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "share_link_otps": {
+      "name": "share_link_otps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "otp_hash": {
+          "name": "otp_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "share_link_otps_link_id_share_links_id_fk": {
+          "name": "share_link_otps_link_id_share_links_id_fk",
+          "tableFrom": "share_link_otps",
+          "tableTo": "share_links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "share_link_otps_id": {
+          "name": "share_link_otps_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "share_links": {
+      "name": "share_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_downloads": {
+          "name": "max_downloads",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "download_count": {
+          "name": "download_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "idx_share_links_token": {
+          "name": "idx_share_links_token",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_share_links_file_id": {
+          "name": "idx_share_links_file_id",
+          "columns": [
+            "file_id"
+          ],
+          "isUnique": false
+        },
+        "idx_share_links_folder_id": {
+          "name": "idx_share_links_folder_id",
+          "columns": [
+            "folder_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "share_links_file_id_files_id_fk": {
+          "name": "share_links_file_id_files_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "share_links_folder_id_folders_id_fk": {
+          "name": "share_links_folder_id_folders_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "folders",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "share_links_created_by_users_id_fk": {
+          "name": "share_links_created_by_users_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "share_links_id": {
+          "name": "share_links_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_token_hash": {
+          "name": "session_token_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_expires_at": {
+          "name": "session_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_expires_at": {
+          "name": "refresh_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "sessions_id": {
+          "name": "sessions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "upload_sessions": {
+      "name": "upload_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_chunks": {
+          "name": "total_chunks",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_chunks": {
+          "name": "completed_chunks",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('uploading','completed','failed','expired')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'uploading'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "idx_upload_sessions_user_file": {
+          "name": "idx_upload_sessions_user_file",
+          "columns": [
+            "user_id",
+            "file_name",
+            "file_size",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "upload_sessions_user_id_users_id_fk": {
+          "name": "upload_sessions_user_id_users_id_fk",
+          "tableFrom": "upload_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "upload_sessions_file_id_files_id_fk": {
+          "name": "upload_sessions_file_id_files_id_fk",
+          "tableFrom": "upload_sessions",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "upload_sessions_id": {
+          "name": "upload_sessions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_uek": {
+          "name": "encrypted_uek",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_used": {
+          "name": "storage_used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "storage_quota": {
+          "name": "storage_quota",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1073741824
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "users_id": {
+          "name": "users_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/secure-vault/drizzle/meta/_journal.json
+++ b/secure-vault/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1774797788494,
       "tag": "0003_greedy_ultron",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "5",
+      "when": 1775260334081,
+      "tag": "0004_next_pestilence",
+      "breakpoints": true
     }
   ]
 }

--- a/secure-vault/next.config.ts
+++ b/secure-vault/next.config.ts
@@ -41,6 +41,19 @@ const nextConfig: NextConfig = {
       {
         headers: [
           { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "X-Frame-Options", value: "SAMEORIGIN" },
+          { key: "X-XSS-Protection", value: "1; mode=block" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          {
+            key: "Content-Security-Policy",
+            value: previewContentSecurityPolicy,
+          },
+        ],
+        source: "/api/share/:token/preview",
+      },
+      {
+        headers: [
+          { key: "X-Content-Type-Options", value: "nosniff" },
           { key: "X-Frame-Options", value: "DENY" },
           { key: "X-XSS-Protection", value: "1; mode=block" },
           { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
@@ -49,7 +62,7 @@ const nextConfig: NextConfig = {
             value: contentSecurityPolicy,
           },
         ],
-        source: "/((?!api/files/[^/]+/preview$).*)",
+        source: "/((?!api/files/[^/]+/preview$|api/share/[^/]+/preview$).*)",
       },
     ];
 

--- a/secure-vault/package-lock.json
+++ b/secure-vault/package-lock.json
@@ -29,6 +29,7 @@
         "radix-ui": "^1.4.3",
         "react": "19.2.3",
         "react-dom": "19.2.3",
+        "resend": "^6.10.0",
         "shadcn": "^4.0.2",
         "sharp": "^0.34.5",
         "sonner": "^2.0.7",
@@ -47,6 +48,7 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "babel-plugin-react-compiler": "1.0.0",
+        "cross-env": "^10.1.0",
         "drizzle-kit": "^0.31.10",
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
@@ -6559,6 +6561,12 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -10355,6 +10363,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -13480,6 +13494,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
@@ -14001,6 +14021,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.10.0.tgz",
+      "integrity": "sha512-i7CwZpYj4Oho1RxsTpLcCUkO08+HiL4NXrm6jLJ2WzJ89UGI8eROSieLONJA3hnUrf1OYnCyfq5F6POnHUMv1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "svix": "1.88.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve": {
@@ -14729,6 +14770,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -15073,6 +15124,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.88.0",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.88.0.tgz",
+      "integrity": "sha512-vm/JrrUd3bVyBE+3L33TIyVSs8gS5fYx7lrISvKlDJXTYX1ACH4REX8P1tHxsSKoZi/rvifM1t0XRc5Vc45THw==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0",
+        "uuid": "^10.0.0"
       }
     },
     "node_modules/symbol-tree": {
@@ -16249,6 +16310,19 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/validate-npm-package-name": {
       "version": "7.0.2",

--- a/secure-vault/package.json
+++ b/secure-vault/package.json
@@ -35,6 +35,7 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "resend": "^6.10.0",
     "shadcn": "^4.0.2",
     "sharp": "^0.34.5",
     "sonner": "^2.0.7",
@@ -45,8 +46,8 @@
     "zxcvbn": "^4.4.2"
   },
   "devDependencies": {
-    "@tailwindcss/postcss": "^4",
     "@playwright/test": "^1.54.2",
+    "@tailwindcss/postcss": "^4",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^20.19.37",

--- a/secure-vault/src/app/(dashboard)/files/share-actions.ts
+++ b/secure-vault/src/app/(dashboard)/files/share-actions.ts
@@ -1,0 +1,61 @@
+"use server";
+
+import { requireVerifiedUser } from "@/lib/auth/get-current-user";
+import {
+  createShareLink,
+  getShareLinkForOwnerById,
+  revokeShareLink,
+  updateShareLinkSettings,
+} from "@/lib/sharing/share-service";
+import { revalidatePath } from "next/cache";
+
+export async function createShareLinkAction(input: {
+  fileId?: string;
+  folderId?: string;
+  expiresAt: Date | null;
+  maxDownloads: number | null;
+  allowedEmails: string[];
+}) {
+  const user = await requireVerifiedUser();
+
+  const result = await createShareLink({
+    createdBy: user.id,
+    ...input,
+  });
+
+  revalidatePath("/files");
+  return { success: true, link: result };
+}
+
+export async function revokeShareLinkAction(linkId: string) {
+  const user = await requireVerifiedUser();
+  const link = await getShareLinkForOwnerById({ id: linkId, ownerId: user.id });
+
+  await revokeShareLink({
+    ownerId: user.id,
+    id: linkId,
+  });
+
+  revalidatePath("/files");
+  revalidatePath(`/s/${link.token}`);
+  return { success: true };
+}
+
+export async function updateShareLinkSettingsAction(input: {
+  allowedEmails: string[];
+  linkId: string;
+  maxDownloads: number | null;
+}) {
+  const user = await requireVerifiedUser();
+
+  const link = await updateShareLinkSettings({
+    allowedEmails: input.allowedEmails,
+    id: input.linkId,
+    maxDownloads: input.maxDownloads,
+    ownerId: user.id,
+  });
+
+  revalidatePath("/files");
+  revalidatePath(`/s/${link.token}`);
+  return { success: true, link };
+}

--- a/secure-vault/src/app/api/files/[id]/service.ts
+++ b/secure-vault/src/app/api/files/[id]/service.ts
@@ -1,5 +1,8 @@
 import { asc, and, eq, isNull } from "drizzle-orm";
 
+import { decryptUEK } from "@/lib/crypto";
+import { users } from "@/lib/db/schema";
+
 import type { CurrentUser } from "@/lib/auth/get-current-user";
 import { createDecryptStream, decryptFEK, sanitizeFilename } from "@/lib/crypto";
 import { MariadbConnection } from "@/lib/db";
@@ -58,6 +61,51 @@ export async function streamOwnedFile(options: {
   validateChunkMetadata(file.chunks, file.totalChunks);
 
   const fek = decryptFEK(file.encryptedFek, options.user.uek);
+  const body = createDecryptedFileStream(file.chunks, fek, options.signal);
+
+  return new Response(body, {
+    headers: {
+      "Cache-Control": "private, no-store",
+      "Content-Disposition": buildContentDisposition(file.name, options.disposition),
+      "Content-Length": String(file.size),
+      "Content-Type": file.mimeType || "application/octet-stream",
+      "X-Content-Type-Options": "nosniff",
+    },
+    status: 200,
+  });
+}
+
+export async function streamSharedFile(options: {
+  disposition: DownloadDisposition;
+  fileId: string;
+  ownerId: string;
+  signal?: AbortSignal;
+}): Promise<Response> {
+  const db = MariadbConnection.getConnection();
+  const [owner] = await db
+    .select({ encrypted_uek: users.encrypted_uek })
+    .from(users)
+    .where(eq(users.id, options.ownerId))
+    .limit(1);
+
+  if (!owner) {
+    throw new FileDownloadServiceError("Owner not found", 404);
+  }
+
+  const uek = decryptUEK(owner.encrypted_uek);
+  const file = await findDownloadableFile(options.ownerId, options.fileId);
+
+  if (!file) {
+    throw new FileDownloadServiceError("File not found", 404);
+  }
+
+  if (options.disposition === "inline" && !canPreviewMime(file.mimeType)) {
+    throw new FileDownloadServiceError("Preview is not supported for this file type", 415);
+  }
+
+  validateChunkMetadata(file.chunks, file.totalChunks);
+
+  const fek = decryptFEK(file.encryptedFek, uek);
   const body = createDecryptedFileStream(file.chunks, fek, options.signal);
 
   return new Response(body, {

--- a/secure-vault/src/app/api/files/service.ts
+++ b/secure-vault/src/app/api/files/service.ts
@@ -561,6 +561,12 @@ export async function moveFolder(
     );
 
   if (getAffectedCount(result) === 0) {
+    const currentFolder = await getScopedFolderRecord(userId, folderId);
+
+    if (currentFolder?.parentId === targetParentId) {
+      return mapFolderListItem(currentFolder);
+    }
+
     if (existingFolder.parentId === targetParentId) {
       return mapFolderListItem(existingFolder);
     }
@@ -570,7 +576,10 @@ export async function moveFolder(
 
   const updatedFolder = await getScopedFolderRecord(userId, folderId);
   if (!updatedFolder) {
-    throw new Error("Folder not found");
+    return mapFolderListItem({
+      ...existingFolder,
+      parentId: targetParentId,
+    });
   }
 
   return mapFolderListItem(updatedFolder);

--- a/secure-vault/src/app/api/share/[token]/download/route.ts
+++ b/secure-vault/src/app/api/share/[token]/download/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { FileDownloadServiceError, streamSharedFile } from "@/app/api/files/[id]/service";
+import { requireValidShareAccessSession } from "@/lib/sharing/share-access-session";
+import {
+  assertDownloadAllowed,
+  assertShareLinkAccessible,
+  recordShareAccess,
+  requireFolderShareTargetFile,
+  requireShareLinkByToken,
+  ShareServiceError,
+} from "@/lib/sharing/share-service";
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ token: string }> },
+) {
+  try {
+    const { token } = await context.params;
+    const link = await requireShareLinkByToken(token);
+    assertShareLinkAccessible(link);
+
+    let verifiedEmail: string | null = null;
+
+    if (!link.is_public && link.allowedEmails.length > 0) {
+      const session = await requireValidShareAccessSession({ linkId: link.id, token });
+
+      if (!session) {
+        return NextResponse.json({ error: "Access denied" }, { status: 403 });
+      }
+
+      verifiedEmail = session.email;
+    }
+
+    const { searchParams } = new URL(request.url);
+    const fileId =
+      link.targetType === "file"
+        ? link.targetId
+        : await requireFolderShareTargetFile({
+            fileId: searchParams.get("fileId")?.trim() ?? "",
+            ownerId: link.created_by,
+            rootFolderId: link.targetId,
+          });
+
+    const response = await streamSharedFile({
+      disposition: "attachment",
+      fileId,
+      ownerId: link.created_by,
+      signal: request.signal,
+    });
+
+    await assertDownloadAllowed(link.id);
+
+    await recordShareAccess({
+      email: verifiedEmail,
+      ipAddress: request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown",
+      linkId: link.id,
+      userAgent: request.headers.get("user-agent") ?? undefined,
+    });
+
+    return response;
+  } catch (error) {
+    if (error instanceof ShareServiceError) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
+    }
+
+    if (error instanceof FileDownloadServiceError) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
+    }
+
+    console.error("Shared download failed", error);
+    return NextResponse.json({ error: "Failed to stream file" }, { status: 500 });
+  }
+}

--- a/secure-vault/src/app/api/share/[token]/folder/route.ts
+++ b/secure-vault/src/app/api/share/[token]/folder/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { requireValidShareAccessSession } from "@/lib/sharing/share-access-session";
+import {
+  assertShareLinkAccessible,
+  requireSharedFolderContents,
+  requireShareLinkByToken,
+  ShareServiceError,
+} from "@/lib/sharing/share-service";
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ token: string }> },
+) {
+  try {
+    const { token } = await context.params;
+    const link = await requireShareLinkByToken(token);
+
+    if (link.targetType !== "folder") {
+      return NextResponse.json({ error: "Share link not found" }, { status: 404 });
+    }
+
+    assertShareLinkAccessible(link);
+
+    if (!link.is_public && link.allowedEmails.length > 0) {
+      const session = await requireValidShareAccessSession({ linkId: link.id, token });
+
+      if (!session) {
+        return NextResponse.json({ error: "Access denied" }, { status: 403 });
+      }
+    }
+
+    const currentFolderId =
+      new URL(request.url).searchParams.get("folderId")?.trim() || link.targetId;
+
+    const contents = await requireSharedFolderContents({
+      currentFolderId,
+      ownerId: link.created_by,
+      rootFolderId: link.targetId,
+    });
+
+    return NextResponse.json(contents);
+  } catch (error) {
+    if (error instanceof ShareServiceError) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
+    }
+
+    console.error("Shared folder listing failed", error);
+    return NextResponse.json({ error: "Failed to load folder" }, { status: 500 });
+  }
+}

--- a/secure-vault/src/app/api/share/[token]/logout/route.ts
+++ b/secure-vault/src/app/api/share/[token]/logout/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+
+import { clearShareAccessSession } from "@/lib/sharing/share-access-session";
+import { requireShareLinkByToken, ShareServiceError } from "@/lib/sharing/share-service";
+
+export async function POST(
+  _request: Request,
+  context: { params: Promise<{ token: string }> },
+) {
+  try {
+    const { token } = await context.params;
+    const link = await requireShareLinkByToken(token);
+
+    await clearShareAccessSession(link.id);
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (error instanceof ShareServiceError) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
+    }
+
+    console.error("Share logout failed", error);
+    return NextResponse.json({ error: "Failed to clear share session" }, { status: 500 });
+  }
+}

--- a/secure-vault/src/app/api/share/[token]/preview/route.ts
+++ b/secure-vault/src/app/api/share/[token]/preview/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { FileDownloadServiceError, streamSharedFile } from "@/app/api/files/[id]/service";
+import { requireValidShareAccessSession } from "@/lib/sharing/share-access-session";
+import {
+  assertShareLinkAccessible,
+  recordShareAccess,
+  requireFolderShareTargetFile,
+  requireShareLinkByToken,
+  ShareServiceError,
+} from "@/lib/sharing/share-service";
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ token: string }> },
+) {
+  try {
+    const { token } = await context.params;
+    const link = await requireShareLinkByToken(token);
+    assertShareLinkAccessible(link);
+
+    let verifiedEmail: string | null = null;
+
+    if (!link.is_public && link.allowedEmails.length > 0) {
+      const session = await requireValidShareAccessSession({ linkId: link.id, token });
+
+      if (!session) {
+        return NextResponse.json({ error: "Access denied" }, { status: 403 });
+      }
+
+      verifiedEmail = session.email;
+    }
+
+    const { searchParams } = new URL(request.url);
+    const fileId =
+      link.targetType === "file"
+        ? link.targetId
+        : await requireFolderShareTargetFile({
+            fileId: searchParams.get("fileId")?.trim() ?? "",
+            ownerId: link.created_by,
+            rootFolderId: link.targetId,
+          });
+
+    await recordShareAccess({
+      email: verifiedEmail,
+      ipAddress: request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown",
+      linkId: link.id,
+      userAgent: request.headers.get("user-agent") ?? undefined,
+    });
+
+    return await streamSharedFile({
+      disposition: "inline",
+      fileId,
+      ownerId: link.created_by,
+      signal: request.signal,
+    });
+  } catch (error) {
+    if (error instanceof ShareServiceError) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
+    }
+
+    if (error instanceof FileDownloadServiceError) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
+    }
+
+    console.error("Shared preview failed", error);
+    return NextResponse.json({ error: "Failed to preview file" }, { status: 500 });
+  }
+}

--- a/secure-vault/src/app/api/share/[token]/request-otp/route.ts
+++ b/secure-vault/src/app/api/share/[token]/request-otp/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { createAndSendOtp, isShareOrOtpError } from "@/lib/sharing/otp-service";
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ token: string }> },
+) {
+  try {
+    const { token } = await context.params;
+    const payload = (await request.json().catch(() => null)) as { email?: unknown } | null;
+    const email = typeof payload?.email === "string" ? payload.email : "";
+
+    if (!email.trim()) {
+      return NextResponse.json({ error: "Email is required" }, { status: 400 });
+    }
+
+    await createAndSendOtp({ email, token });
+    return NextResponse.json({
+      message: "If the email is allowed, a code has been sent.",
+      success: true,
+    });
+  } catch (error) {
+    if (isShareOrOtpError(error)) {
+      if (error.code === "EMAIL_NOT_ALLOWED") {
+        return NextResponse.json({
+          message: "If the email is allowed, a code has been sent.",
+          success: true,
+        });
+      }
+
+      return NextResponse.json({ error: error.message }, { status: error.status });
+    }
+
+    console.error("Share OTP request failed", error);
+    return NextResponse.json({ error: "Failed to request verification code" }, { status: 500 });
+  }
+}

--- a/secure-vault/src/app/api/share/[token]/verify-otp/route.ts
+++ b/secure-vault/src/app/api/share/[token]/verify-otp/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { createShareAccessSession } from "@/lib/sharing/share-access-session";
+import { isShareOrOtpError, verifyOtp } from "@/lib/sharing/otp-service";
+import { recordShareAccess } from "@/lib/sharing/share-service";
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ token: string }> },
+) {
+  try {
+    const { token } = await context.params;
+    const payload = (await request.json().catch(() => null)) as {
+      code?: unknown;
+      email?: unknown;
+    } | null;
+    const email = typeof payload?.email === "string" ? payload.email : "";
+    const code = typeof payload?.code === "string" ? payload.code : "";
+
+    if (!email.trim() || !code.trim()) {
+      return NextResponse.json({ error: "Email and code are required" }, { status: 400 });
+    }
+
+    const verified = await verifyOtp({ code, email, token });
+    const expiresAt = verified.linkExpiresAt ?? new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+    await createShareAccessSession({
+      email: verified.email,
+      expiresAt,
+      linkId: verified.linkId,
+    });
+
+    await recordShareAccess({
+      email: verified.email,
+      ipAddress: request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown",
+      linkId: verified.linkId,
+      userAgent: request.headers.get("user-agent") ?? undefined,
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (isShareOrOtpError(error)) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
+    }
+
+    console.error("Share OTP verification failed", error);
+    return NextResponse.json({ error: "Failed to verify code" }, { status: 500 });
+  }
+}

--- a/secure-vault/src/app/api/share/links/route.ts
+++ b/secure-vault/src/app/api/share/links/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getCurrentUser } from "@/lib/auth/get-current-user";
+import { listShareLinksForOwner } from "@/lib/sharing/share-service";
+
+export async function GET(request: NextRequest) {
+  const user = await getCurrentUser();
+  if (!user || !user.email_verified) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const fileId = searchParams.get("fileId") || undefined;
+  const folderId = searchParams.get("folderId") || undefined;
+
+  if (fileId && folderId) {
+    return NextResponse.json({ error: "Cannot query both a file and a folder" }, { status: 400 });
+  }
+  if (!fileId && !folderId) {
+    return NextResponse.json({ error: "Must specify either a fileId or folderId" }, { status: 400 });
+  }
+
+  try {
+    const links = await listShareLinksForOwner({
+      ownerId: user.id,
+      fileId,
+      folderId,
+    });
+
+    return NextResponse.json(links);
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/secure-vault/src/app/s/[token]/page.tsx
+++ b/secure-vault/src/app/s/[token]/page.tsx
@@ -1,0 +1,81 @@
+import { notFound } from "next/navigation";
+
+import { ShareAuthView } from "@/components/share/share-auth-view";
+import { SharedFileView } from "@/components/share/shared-file-view";
+import { SharedFolderView } from "@/components/share/shared-folder-view";
+import { requireValidShareAccessSession } from "@/lib/sharing/share-access-session";
+import {
+  assertShareLinkAccessible,
+  requireSharedFileSummary,
+  requireShareLinkByToken,
+  ShareServiceError,
+} from "@/lib/sharing/share-service";
+
+export const dynamic = "force-dynamic";
+
+function ExpiredState() {
+  return (
+    <div className="flex h-screen w-full items-center justify-center p-4">
+      <div className="max-w-md text-center">
+        <h1 className="mb-2 text-2xl font-bold">Link Expired</h1>
+        <p className="text-muted-foreground">
+          This share link has expired and is no longer accessible.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default async function SharedLinkPage(
+  { params }: { params: Promise<{ token: string }> },
+) {
+  const { token } = await params;
+
+  try {
+    const link = await requireShareLinkByToken(token);
+    assertShareLinkAccessible(link);
+
+    let sessionEmail: string | null = null;
+
+    if (!link.is_public && link.allowedEmails.length > 0) {
+      const session = await requireValidShareAccessSession({ linkId: link.id, token });
+
+      if (!session) {
+        return <ShareAuthView token={token} />;
+      }
+
+      sessionEmail = session.email;
+    }
+
+    if (link.targetType === "file") {
+      const file = await requireSharedFileSummary({
+        fileId: link.targetId,
+        ownerId: link.created_by,
+      });
+
+      return (
+        <SharedFileView
+          email={sessionEmail}
+          fileId={file.id}
+          fileName={file.name}
+          mimeType={file.mimeType}
+          token={token}
+        />
+      );
+    }
+
+    return <SharedFolderView token={token} email={sessionEmail} rootFolderId={link.targetId} />;
+  } catch (error) {
+    if (error instanceof ShareServiceError) {
+      if (error.code === "NOT_FOUND") {
+        notFound();
+      }
+
+      if (error.code === "EXPIRED") {
+        return <ExpiredState />;
+      }
+    }
+
+    throw error;
+  }
+}

--- a/secure-vault/src/components/files/file-actions-menu.tsx
+++ b/secure-vault/src/components/files/file-actions-menu.tsx
@@ -17,6 +17,7 @@ type FileActionsMenuProps = {
   onDelete: (file: FileListItem) => void;
   onMove: (file: FileListItem) => void;
   onRename: (file: FileListItem) => void;
+  onShare: (file: FileListItem) => void;
 };
 
 export function FileActionsMenu({
@@ -24,6 +25,7 @@ export function FileActionsMenu({
   onDelete,
   onMove,
   onRename,
+  onShare,
 }: FileActionsMenuProps) {
   return (
     <DropdownMenu>
@@ -40,6 +42,7 @@ export function FileActionsMenu({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
+        <DropdownMenuItem onSelect={() => onShare(file)}>Share</DropdownMenuItem>
         <DropdownMenuItem onSelect={() => onRename(file)}>Rename</DropdownMenuItem>
         <DropdownMenuItem onSelect={() => onMove(file)}>Move</DropdownMenuItem>
         <DropdownMenuItem

--- a/secure-vault/src/components/files/file-grid.tsx
+++ b/secure-vault/src/components/files/file-grid.tsx
@@ -19,7 +19,9 @@ type FileGridProps = {
   files: FileListItem[];
   folders: FolderListItem[];
   onDelete: (file: FileListItem) => void;
+  onShare: (file: FileListItem) => void;
   onFolderDelete: (folder: FolderListItem) => void;
+  onFolderShare: (folder: FolderListItem) => void;
   onFolderMove: (folder: FolderListItem) => void;
   onFolderOpen: (folderId: string) => void;
   onFolderRenameCancel: () => void;
@@ -40,7 +42,9 @@ export function FileGrid({
   files,
   folders,
   onDelete,
+  onShare,
   onFolderDelete,
+  onFolderShare,
   onFolderMove,
   onFolderOpen,
   onFolderRenameCancel,
@@ -79,6 +83,7 @@ export function FileGrid({
                   onDelete={onFolderDelete}
                   onMove={onFolderMove}
                   onRename={onFolderRenameStart}
+                  onShare={onFolderShare}
                 />
               </div>
             </div>
@@ -166,7 +171,8 @@ export function FileGrid({
                 onDelete={onDelete}
                 onMove={onMove}
                 onRename={onRenameStart}
-              />
+                  onShare={onShare}
+                />
             </div>
 
             <div className="space-y-2">

--- a/secure-vault/src/components/files/file-list.tsx
+++ b/secure-vault/src/components/files/file-list.tsx
@@ -21,7 +21,9 @@ type FileListProps = {
   files: FileListItem[];
   folders: FolderListItem[];
   onDelete: (file: FileListItem) => void;
+  onShare: (file: FileListItem) => void;
   onFolderDelete: (folder: FolderListItem) => void;
+  onFolderShare: (folder: FolderListItem) => void;
   onFolderMove: (folder: FolderListItem) => void;
   onFolderOpen: (folderId: string) => void;
   onFolderRenameCancel: () => void;
@@ -76,7 +78,9 @@ export function FileList({
   files,
   folders,
   onDelete,
+  onShare,
   onFolderDelete,
+  onFolderShare,
   onFolderMove,
   onFolderOpen,
   onFolderRenameCancel,
@@ -233,7 +237,8 @@ export function FileList({
                     onDelete={onFolderDelete}
                     onMove={onFolderMove}
                     onRename={onFolderRenameStart}
-                  />
+                  onShare={onFolderShare}
+                />
                 </div>
               </td>
             </tr>
@@ -314,7 +319,8 @@ export function FileList({
                       onDelete={onDelete}
                       onMove={onMove}
                       onRename={onRenameStart}
-                    />
+                  onShare={onShare}
+                />
                   </div>
                 </td>
               </tr>

--- a/secure-vault/src/components/files/files-breadcrumbs.tsx
+++ b/secure-vault/src/components/files/files-breadcrumbs.tsx
@@ -16,6 +16,7 @@ type FilesBreadcrumbsProps = {
         onDelete: (folder: FolderListItem) => void;
         onMove: (folder: FolderListItem) => void;
         onRename: (folder: FolderListItem) => void;
+        onShare: (folder: FolderListItem) => void;
       }
     | undefined;
   isFetching: boolean;
@@ -94,6 +95,7 @@ export function FilesBreadcrumbs({
                 onDelete={currentFolderActions.onDelete}
                 onMove={currentFolderActions.onMove}
                 onRename={currentFolderActions.onRename}
+                onShare={currentFolderActions.onShare}
               />
             ) : null}
           </div>

--- a/secure-vault/src/components/files/files-library.tsx
+++ b/secure-vault/src/components/files/files-library.tsx
@@ -34,6 +34,7 @@ import { FileGrid } from "@/components/files/file-grid";
 import { FileList } from "@/components/files/file-list";
 import { MoveFilesDialog } from "@/components/files/move-files-dialog";
 import { Toolbar } from "@/components/files/toolbar";
+import { CreateShareDialog } from "@/components/share/create-share-dialog";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { useFilesExplorerQuery } from "@/hooks/use-files-explorer-query";
 import { sanitizeFilename } from "@/lib/crypto/sanitize";
@@ -63,6 +64,10 @@ type MoveDialogState =
 type DeleteDialogState =
   | { fileIds: string[]; type: "files" }
   | { folderId: string; type: "folder" }
+  | null;
+
+type ShareDialogState =
+  | { id: string; name: string; type: "file" | "folder" }
   | null;
 
 const defaultSort: FileSortState = {
@@ -100,6 +105,7 @@ export function FilesLibrary({
   const [isCreateFolderDialogOpen, setIsCreateFolderDialogOpen] = React.useState(false);
   const [moveDialogState, setMoveDialogState] = React.useState<MoveDialogState>(null);
   const [deleteDialogState, setDeleteDialogState] = React.useState<DeleteDialogState>(null);
+  const [shareDialogState, setShareDialogState] = React.useState<ShareDialogState>(null);
   const [isMovePending, setIsMovePending] = React.useState(false);
   const [isDeletePending, setIsDeletePending] = React.useState(false);
   const [isCreateFolderPending, setIsCreateFolderPending] = React.useState(false);
@@ -273,6 +279,14 @@ export function FilesLibrary({
 
   function openFolderDeleteDialog(folder: FolderListItem) {
     setDeleteDialogState({ folderId: folder.id, type: "folder" });
+  }
+
+  function openFileShareDialog(file: FileListItem) {
+    setShareDialogState({ id: file.id, name: file.name, type: "file" });
+  }
+
+  function openFolderShareDialog(folder: FolderListItem) {
+    setShareDialogState({ id: folder.id, name: folder.name, type: "folder" });
   }
 
   function startFileRename(file: FileListItem) {
@@ -600,6 +614,7 @@ export function FilesLibrary({
                     onDelete: openFolderDeleteDialog,
                     onMove: openFolderMoveDialog,
                     onRename: startFolderRename,
+                    onShare: openFolderShareDialog,
                   }
                 : undefined
             }
@@ -642,6 +657,8 @@ export function FilesLibrary({
               onFolderDelete={openFolderDeleteDialog}
               onFolderMove={openFolderMoveDialog}
               onFolderOpen={navigateToFolder}
+              onFolderShare={openFolderShareDialog}
+              onShare={openFileShareDialog}
               onFolderRenameCancel={cancelRename}
               onFolderRenameChange={setRenameDraft}
               onFolderRenameCommit={commitFolderRename}
@@ -663,6 +680,8 @@ export function FilesLibrary({
               onFolderDelete={openFolderDeleteDialog}
               onFolderMove={openFolderMoveDialog}
               onFolderOpen={navigateToFolder}
+              onFolderShare={openFolderShareDialog}
+              onShare={openFileShareDialog}
               onFolderRenameCancel={cancelRename}
               onFolderRenameChange={setRenameDraft}
               onFolderRenameCommit={commitFolderRename}
@@ -734,6 +753,20 @@ export function FilesLibrary({
           }}
           title={deleteDialogTitle}
         />
+
+        {shareDialogState && (
+          <CreateShareDialog
+            isOpen={true}
+            onOpenChange={(open) => {
+              if (!open) {
+                setShareDialogState(null);
+              }
+            }}
+            targetType={shareDialogState.type}
+            targetId={shareDialogState.id}
+            targetName={shareDialogState.name}
+          />
+        )}
       </CardContent>
     </Card>
   );

--- a/secure-vault/src/components/files/folder-actions-menu.tsx
+++ b/secure-vault/src/components/files/folder-actions-menu.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import type { FolderListItem } from "@/lib/files/types";
@@ -17,6 +18,7 @@ type FolderActionsMenuProps = {
   onDelete: (folder: FolderListItem) => void;
   onMove: (folder: FolderListItem) => void;
   onRename: (folder: FolderListItem) => void;
+  onShare: (folder: FolderListItem) => void;
 };
 
 export function FolderActionsMenu({
@@ -24,6 +26,7 @@ export function FolderActionsMenu({
   onDelete,
   onMove,
   onRename,
+  onShare,
 }: FolderActionsMenuProps) {
   const [open, setOpen] = React.useState(false);
   const pendingRenameRef = React.useRef<FolderListItem | null>(null);
@@ -74,6 +77,7 @@ export function FolderActionsMenu({
           skipCloseAutoFocusRef.current = false;
         }}
       >
+        <DropdownMenuItem onSelect={() => onShare(folder)}>Share</DropdownMenuItem>
         <DropdownMenuItem
           onSelect={() => {
             skipCloseAutoFocusRef.current = true;
@@ -84,6 +88,7 @@ export function FolderActionsMenu({
           Rename
         </DropdownMenuItem>
         <DropdownMenuItem onSelect={() => onMove(folder)}>Move</DropdownMenuItem>
+        <DropdownMenuSeparator />
         <DropdownMenuItem
           className="text-destructive focus:text-destructive"
           onSelect={() => onDelete(folder)}

--- a/secure-vault/src/components/share/create-share-dialog.tsx
+++ b/secure-vault/src/components/share/create-share-dialog.tsx
@@ -92,7 +92,7 @@ export function CreateShareDialog({
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[500px]">
+      <DialogContent className="sm:max-w-[500px]" data-testid="share-dialog">
         <DialogHeader>
           <DialogTitle>Share {targetType === "file" ? "File" : "Folder"}</DialogTitle>
           <DialogDescription>

--- a/secure-vault/src/components/share/create-share-dialog.tsx
+++ b/secure-vault/src/components/share/create-share-dialog.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import * as React from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { createShareLinkAction } from "@/app/(dashboard)/files/share-actions";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+import { toast } from "sonner";
+import { ShareLinksList, type ShareLinksListItem } from "./share-links-list";
+
+type CreateShareDialogProps = {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  targetType: "file" | "folder";
+  targetId: string;
+  targetName: string;
+};
+
+export function CreateShareDialog({
+  isOpen,
+  onOpenChange,
+  targetType,
+  targetId,
+  targetName,
+}: CreateShareDialogProps) {
+  const queryClient = useQueryClient();
+  const [expiry, setExpiry] = React.useState<string>("never");
+  const [maxDownloads, setMaxDownloads] = React.useState<string>("");
+  const [allowedEmails, setAllowedEmails] = React.useState<string>("");
+
+  const queryKey = ["shareLinks", targetType, targetId];
+
+  const { data: links = [], isLoading } = useQuery<ShareLinksListItem[]>({
+    queryKey,
+    queryFn: async () => {
+      const res = await fetch(`/api/share/links?${targetType}Id=${targetId}`);
+      if (!res.ok) throw new Error("Failed to fetch links");
+      return res.json();
+    },
+    enabled: isOpen,
+  });
+
+  const generateLink = useMutation({
+    mutationFn: async () => {
+      let expiresAt: Date | null = null;
+      if (expiry !== "never") {
+        expiresAt = new Date();
+        if (expiry === "1h") expiresAt.setHours(expiresAt.getHours() + 1);
+        if (expiry === "24h") expiresAt.setHours(expiresAt.getHours() + 24);
+        if (expiry === "7d") expiresAt.setDate(expiresAt.getDate() + 7);
+        if (expiry === "30d") expiresAt.setDate(expiresAt.getDate() + 30);
+      }
+
+      const emails = allowedEmails
+        .split(",")
+        .map((e) => e.trim())
+        .filter(Boolean);
+
+      const parsedDownloads = parseInt(maxDownloads, 10);
+      const limit = isNaN(parsedDownloads) || parsedDownloads <= 0 ? null : parsedDownloads;
+
+      const res = await createShareLinkAction({
+        [targetType + "Id"]: targetId,
+        expiresAt,
+        maxDownloads: limit,
+        allowedEmails: emails,
+      });
+
+      if (!res.success) throw new Error("Failed to create share link");
+      return res.link;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey });
+      toast.success("Share link created");
+      setExpiry("never");
+      setMaxDownloads("");
+      setAllowedEmails("");
+    },
+    onError: (err: any) => {
+      toast.error(err.message);
+    },
+  });
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle>Share {targetType === "file" ? "File" : "Folder"}</DialogTitle>
+          <DialogDescription>
+            Share "{targetName}" with others.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-5 py-4">
+          <div className="space-y-2">
+            <Label htmlFor="expiry">Expiry</Label>
+            <select
+              value={expiry}
+              onChange={(e) => setExpiry(e.target.value)}
+              className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <option value="1h">1 Hour</option>
+              <option value="24h">24 Hours</option>
+              <option value="7d">7 Days</option>
+              <option value="30d">30 Days</option>
+              <option value="never">Never</option>
+            </select>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="maxDownloads">Max Downloads</Label>
+            <Input
+              id="maxDownloads"
+              placeholder="Leave empty for unlimited"
+              type="number"
+              min="1"
+              value={maxDownloads}
+              onChange={(e) => setMaxDownloads(e.target.value)}
+            />
+            <p className="text-xs text-muted-foreground">
+              This limit applies to the link as a whole, not per visitor or per email.
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="emails">Allowed Emails</Label>
+            <Input
+              id="emails"
+              placeholder="comma separated (leave empty for public link)"
+              value={allowedEmails}
+              onChange={(e) => setAllowedEmails(e.target.value)}
+            />
+            <p className="text-xs text-muted-foreground">
+              Leave empty to create a public link. Add comma-separated emails to require OTP verification.
+            </p>
+          </div>
+
+          <div className="flex justify-end">
+            <Button onClick={() => generateLink.mutate()} disabled={generateLink.isPending}>
+              {generateLink.isPending ? "Generating..." : "Generate Link"}
+            </Button>
+          </div>
+
+          <div className="mt-4 border-t pt-4">
+            <h4 className="mb-2 font-medium">Existing Links</h4>
+            <ShareLinksList
+              links={links}
+              isLoading={isLoading}
+              onRevoke={() => queryClient.invalidateQueries({ queryKey })}
+            />
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/secure-vault/src/components/share/share-auth-view.tsx
+++ b/secure-vault/src/components/share/share-auth-view.tsx
@@ -11,10 +11,12 @@ export function ShareAuthView({ token }: { token: string }) {
   const [step, setStep] = React.useState<"email" | "otp">("email");
   const [email, setEmail] = React.useState("");
   const [code, setCode] = React.useState("");
+  const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
   const [isPending, setIsPending] = React.useState(false);
 
   const handleRequestOtp = async (e: React.FormEvent) => {
     e.preventDefault();
+    setErrorMessage(null);
     setIsPending(true);
     try {
       const res = await fetch(`/api/share/${token}/request-otp`, {
@@ -33,7 +35,9 @@ export function ShareAuthView({ token }: { token: string }) {
       );
       setStep("otp");
     } catch (err: any) {
-      toast.error(err.message);
+      const message = err instanceof Error ? err.message : "Failed to request OTP";
+      setErrorMessage(message);
+      toast.error(message);
     } finally {
       setIsPending(false);
     }
@@ -41,6 +45,7 @@ export function ShareAuthView({ token }: { token: string }) {
 
   const handleVerifyOtp = async (e: React.FormEvent) => {
     e.preventDefault();
+    setErrorMessage(null);
     setIsPending(true);
     try {
       const res = await fetch(`/api/share/${token}/verify-otp`, {
@@ -55,7 +60,9 @@ export function ShareAuthView({ token }: { token: string }) {
       toast.success("Access granted");
       window.location.assign(`/s/${token}`);
     } catch (err: any) {
-      toast.error(err.message);
+      const message = err instanceof Error ? err.message : "Failed to verify OTP";
+      setErrorMessage(message);
+      toast.error(message);
     } finally {
       setIsPending(false);
     }
@@ -83,10 +90,20 @@ export function ShareAuthView({ token }: { token: string }) {
                 type="email"
                 required
                 value={email}
-                onChange={(e) => setEmail(e.target.value)}
+                onChange={(e) => {
+                  setEmail(e.target.value);
+                  if (errorMessage) {
+                    setErrorMessage(null);
+                  }
+                }}
                 placeholder="Enter your email"
               />
             </div>
+            {errorMessage ? (
+              <p className="text-sm text-destructive" data-testid="share-auth-error" role="alert">
+                {errorMessage}
+              </p>
+            ) : null}
             <Button type="submit" className="w-full" disabled={isPending}>
               {isPending ? "Sending..." : "Send Verification Code"}
             </Button>
@@ -100,19 +117,33 @@ export function ShareAuthView({ token }: { token: string }) {
                 type="text"
                 required
                 value={code}
-                onChange={(e) => setCode(e.target.value)}
+                onChange={(e) => {
+                  setCode(e.target.value);
+                  if (errorMessage) {
+                    setErrorMessage(null);
+                  }
+                }}
                 placeholder="Enter 6-digit code"
                 maxLength={6}
                 autoComplete="one-time-code"
               />
             </div>
+            {errorMessage ? (
+              <p className="text-sm text-destructive" data-testid="share-auth-error" role="alert">
+                {errorMessage}
+              </p>
+            ) : null}
             <Button type="submit" className="w-full" disabled={isPending}>
               {isPending ? "Verifying..." : "Verify and Access"}
             </Button>
             <div className="text-center mt-2">
               <button 
                 type="button" 
-                onClick={() => setStep("email")} 
+                onClick={() => {
+                  setStep("email");
+                  setCode("");
+                  setErrorMessage(null);
+                }} 
                 className="text-sm text-muted-foreground hover:text-foreground"
               >
                 Use a different email

--- a/secure-vault/src/components/share/share-auth-view.tsx
+++ b/secure-vault/src/components/share/share-auth-view.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import * as React from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { toast } from "sonner";
+import { LockIcon } from "lucide-react";
+
+export function ShareAuthView({ token }: { token: string }) {
+  const [step, setStep] = React.useState<"email" | "otp">("email");
+  const [email, setEmail] = React.useState("");
+  const [code, setCode] = React.useState("");
+  const [isPending, setIsPending] = React.useState(false);
+
+  const handleRequestOtp = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsPending(true);
+    try {
+      const res = await fetch(`/api/share/${token}/request-otp`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data.error || "Failed to request OTP");
+      }
+      toast.success(
+        process.env.NODE_ENV !== "production"
+          ? "Verification code logged in the server terminal. Resend is implemented but bypassed locally because it requires a verified domain."
+          : (data.message || "OTP sent if email is allowed"),
+      );
+      setStep("otp");
+    } catch (err: any) {
+      toast.error(err.message);
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  const handleVerifyOtp = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsPending(true);
+    try {
+      const res = await fetch(`/api/share/${token}/verify-otp`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, code }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || "Failed to verify OTP");
+      }
+      toast.success("Access granted");
+      window.location.assign(`/s/${token}`);
+    } catch (err: any) {
+      toast.error(err.message);
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen w-full items-center justify-center p-4 bg-muted/30">
+      <div className="w-full max-w-sm rounded-lg border bg-background p-6 shadow-sm">
+        <div className="mb-6 flex flex-col items-center text-center">
+          <div className="flex size-12 items-center justify-center rounded-full bg-primary/10 text-primary mb-4">
+            <LockIcon className="size-6" />
+          </div>
+          <h1 className="text-xl font-semibold">Secure Share Link</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            This link is restricted. Please verify your identity.
+          </p>
+        </div>
+
+        {step === "email" ? (
+          <form onSubmit={handleRequestOtp} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="email">Email Address</Label>
+              <Input
+                id="email"
+                type="email"
+                required
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="Enter your email"
+              />
+            </div>
+            <Button type="submit" className="w-full" disabled={isPending}>
+              {isPending ? "Sending..." : "Send Verification Code"}
+            </Button>
+          </form>
+        ) : (
+          <form onSubmit={handleVerifyOtp} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="code">Verification Code</Label>
+              <Input
+                id="code"
+                type="text"
+                required
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+                placeholder="Enter 6-digit code"
+                maxLength={6}
+                autoComplete="one-time-code"
+              />
+            </div>
+            <Button type="submit" className="w-full" disabled={isPending}>
+              {isPending ? "Verifying..." : "Verify and Access"}
+            </Button>
+            <div className="text-center mt-2">
+              <button 
+                type="button" 
+                onClick={() => setStep("email")} 
+                className="text-sm text-muted-foreground hover:text-foreground"
+              >
+                Use a different email
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/secure-vault/src/components/share/share-links-list.tsx
+++ b/secure-vault/src/components/share/share-links-list.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import * as React from "react";
+import { Copy, Pencil, Trash2 } from "lucide-react";
+
+import {
+  revokeShareLinkAction,
+  updateShareLinkSettingsAction,
+} from "@/app/(dashboard)/files/share-actions";
+import { formatExplorerDate } from "@/components/files/file-browser-utils";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { toast } from "sonner";
+
+export type ShareLinksListItem = {
+  allowedEmails: string[];
+  created_at: string;
+  download_count: number;
+  expires_at: string | null;
+  id: string;
+  is_public: boolean;
+  max_downloads: number | null;
+  token: string;
+};
+
+export function ShareLinksList({
+  isLoading,
+  links,
+  onRevoke,
+}: {
+  isLoading: boolean;
+  links: ShareLinksListItem[];
+  onRevoke: () => void;
+}) {
+  if (isLoading) {
+    return <div className="text-sm text-muted-foreground">Loading...</div>;
+  }
+
+  if (links.length === 0) {
+    return <div className="text-sm text-muted-foreground">No active share links.</div>;
+  }
+
+  const [editingLinkId, setEditingLinkId] = React.useState<string | null>(null);
+  const [emailDraft, setEmailDraft] = React.useState("");
+  const [maxDownloadsDraft, setMaxDownloadsDraft] = React.useState("");
+  const [savingLinkId, setSavingLinkId] = React.useState<string | null>(null);
+
+  function renderDownloadSummary(link: ShareLinksListItem) {
+    if (link.max_downloads === null) {
+      return `Downloads used: ${link.download_count} (unlimited)`;
+    }
+
+    if (link.download_count >= link.max_downloads) {
+      return `Download limit reached: ${link.download_count} used of ${link.max_downloads}`;
+    }
+
+    return `Downloads used: ${link.download_count} of ${link.max_downloads}`;
+  }
+
+  async function handleRevoke(id: string) {
+    try {
+      const response = await revokeShareLinkAction(id);
+
+      if (!response.success) {
+        throw new Error("Failed to revoke link");
+      }
+
+      toast.success("Link revoked");
+      onRevoke();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to revoke link");
+    }
+  }
+
+  async function handleCopy(token: string) {
+    try {
+      await navigator.clipboard.writeText(`${window.location.origin}/s/${token}`);
+      toast.success("Link copied to clipboard");
+    } catch {
+      toast.error("Failed to copy link");
+    }
+  }
+
+  async function handleSaveSettings(link: ShareLinksListItem) {
+    setSavingLinkId(link.id);
+
+    try {
+      const parsedLimit = Number.parseInt(maxDownloadsDraft, 10);
+      const maxDownloads =
+        maxDownloadsDraft.trim() === "" || Number.isNaN(parsedLimit) || parsedLimit <= 0
+          ? null
+          : parsedLimit;
+
+      const response = await updateShareLinkSettingsAction({
+        allowedEmails: emailDraft.split(",").map((email) => email.trim()).filter(Boolean),
+        linkId: link.id,
+        maxDownloads,
+      });
+
+      if (!response.success) {
+        throw new Error("Failed to update link settings");
+      }
+
+      toast.success("Link settings updated");
+      setEditingLinkId(null);
+      setEmailDraft("");
+      setMaxDownloadsDraft("");
+      onRevoke();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to update link settings");
+    } finally {
+      setSavingLinkId(null);
+    }
+  }
+
+  return (
+    <div className="max-h-60 space-y-3 overflow-y-auto">
+      {links.map((link) => (
+        <div className="rounded-md border p-3 text-sm" key={link.id}>
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0 flex-1 overflow-hidden">
+            <div className="flex items-center space-x-2">
+              <span className="truncate font-medium">/s/{link.token}</span>
+              <span
+                className={`rounded-full px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider ${
+                  link.is_public
+                    ? "bg-green-100 text-green-800"
+                    : "bg-blue-100 text-blue-800"
+                }`}
+              >
+                {link.is_public ? "Public" : "Restricted"}
+              </span>
+            </div>
+            <div className="mt-1 text-xs text-muted-foreground">
+              Created: {formatExplorerDate(link.created_at)}
+              <br />
+              Expires: {link.expires_at ? formatExplorerDate(link.expires_at) : "Never"}
+              <span> &bull; {renderDownloadSummary(link)}</span>
+            </div>
+            <div className="mt-2 text-xs text-muted-foreground">
+              {link.allowedEmails.length > 0
+                ? `Allowed emails: ${link.allowedEmails.join(", ")}`
+                : "Allowed emails: Public link"}
+            </div>
+          </div>
+          <div className="flex shrink-0 space-x-1">
+            <Button
+              className="hover:text-foreground"
+              onClick={() => void handleCopy(link.token)}
+              size="icon-sm"
+              title="Copy Link"
+              variant="ghost"
+            >
+              <Copy className="size-4" />
+            </Button>
+            <Button
+              className="hover:text-foreground"
+              onClick={() => {
+                setEditingLinkId(link.id);
+                setEmailDraft(link.allowedEmails.join(", "));
+                setMaxDownloadsDraft(link.max_downloads?.toString() ?? "");
+              }}
+              size="icon-sm"
+              title="Edit Link Settings"
+              variant="ghost"
+            >
+              <Pencil className="size-4" />
+            </Button>
+            <Button
+              className="text-destructive hover:text-destructive"
+              onClick={() => void handleRevoke(link.id)}
+              size="icon-sm"
+              title="Revoke Link"
+              variant="ghost"
+            >
+              <Trash2 className="size-4" />
+            </Button>
+          </div>
+        </div>
+          {editingLinkId === link.id ? (
+            <div className="mt-3 space-y-2 border-t pt-3">
+              <label className="text-xs font-medium text-foreground" htmlFor={`emails-${link.id}`}>
+                Allowed emails
+              </label>
+              <Input
+                id={`emails-${link.id}`}
+                onChange={(event) => setEmailDraft(event.target.value)}
+                placeholder="comma separated emails, leave empty to make public"
+                value={emailDraft}
+              />
+              <label className="text-xs font-medium text-foreground" htmlFor={`downloads-${link.id}`}>
+                Max downloads
+              </label>
+              <Input
+                id={`downloads-${link.id}`}
+                min="1"
+                onChange={(event) => setMaxDownloadsDraft(event.target.value)}
+                placeholder="Leave empty for unlimited"
+                type="number"
+                value={maxDownloadsDraft}
+              />
+              <p className="text-xs text-muted-foreground">
+                Expiry cannot be changed after creation. Leave max downloads empty for unlimited.
+                The download limit applies to the whole link, not per visitor or per email. You also cannot set it below the number of downloads already used.
+              </p>
+              <div className="flex justify-end gap-2">
+                <Button
+                  onClick={() => {
+                    setEditingLinkId(null);
+                    setEmailDraft("");
+                    setMaxDownloadsDraft("");
+                  }}
+                  size="sm"
+                  type="button"
+                  variant="ghost"
+                >
+                  Cancel
+                </Button>
+                <Button
+                  disabled={savingLinkId === link.id}
+                  onClick={() => void handleSaveSettings(link)}
+                  size="sm"
+                  type="button"
+                >
+                  {savingLinkId === link.id ? "Saving..." : "Save changes"}
+                </Button>
+              </div>
+            </div>
+          ) : null}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/secure-vault/src/components/share/share-links-list.tsx
+++ b/secure-vault/src/components/share/share-links-list.tsx
@@ -42,6 +42,7 @@ export function ShareLinksList({
 
   const [editingLinkId, setEditingLinkId] = React.useState<string | null>(null);
   const [emailDraft, setEmailDraft] = React.useState("");
+  const [formError, setFormError] = React.useState<string | null>(null);
   const [maxDownloadsDraft, setMaxDownloadsDraft] = React.useState("");
   const [savingLinkId, setSavingLinkId] = React.useState<string | null>(null);
 
@@ -82,6 +83,7 @@ export function ShareLinksList({
   }
 
   async function handleSaveSettings(link: ShareLinksListItem) {
+    setFormError(null);
     setSavingLinkId(link.id);
 
     try {
@@ -107,7 +109,10 @@ export function ShareLinksList({
       setMaxDownloadsDraft("");
       onRevoke();
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Failed to update link settings");
+      const message =
+        error instanceof Error ? error.message : "Failed to update link settings";
+      setFormError(message);
+      toast.error(message);
     } finally {
       setSavingLinkId(null);
     }
@@ -116,7 +121,12 @@ export function ShareLinksList({
   return (
     <div className="max-h-60 space-y-3 overflow-y-auto">
       {links.map((link) => (
-        <div className="rounded-md border p-3 text-sm" key={link.id}>
+        <div
+          className="rounded-md border p-3 text-sm"
+          data-testid={`share-link-row-${link.id}`}
+          data-test-share-token={link.token}
+          key={link.id}
+        >
           <div className="flex items-start justify-between gap-3">
             <div className="min-w-0 flex-1 overflow-hidden">
             <div className="flex items-center space-x-2">
@@ -146,6 +156,7 @@ export function ShareLinksList({
           <div className="flex shrink-0 space-x-1">
             <Button
               className="hover:text-foreground"
+              data-testid={`share-link-copy-${link.id}`}
               onClick={() => void handleCopy(link.token)}
               size="icon-sm"
               title="Copy Link"
@@ -155,9 +166,11 @@ export function ShareLinksList({
             </Button>
             <Button
               className="hover:text-foreground"
+              data-testid={`share-link-edit-${link.id}`}
               onClick={() => {
                 setEditingLinkId(link.id);
                 setEmailDraft(link.allowedEmails.join(", "));
+                setFormError(null);
                 setMaxDownloadsDraft(link.max_downloads?.toString() ?? "");
               }}
               size="icon-sm"
@@ -168,6 +181,7 @@ export function ShareLinksList({
             </Button>
             <Button
               className="text-destructive hover:text-destructive"
+              data-testid={`share-link-revoke-${link.id}`}
               onClick={() => void handleRevoke(link.id)}
               size="icon-sm"
               title="Revoke Link"
@@ -184,7 +198,12 @@ export function ShareLinksList({
               </label>
               <Input
                 id={`emails-${link.id}`}
-                onChange={(event) => setEmailDraft(event.target.value)}
+                onChange={(event) => {
+                  setEmailDraft(event.target.value);
+                  if (formError) {
+                    setFormError(null);
+                  }
+                }}
                 placeholder="comma separated emails, leave empty to make public"
                 value={emailDraft}
               />
@@ -194,11 +213,25 @@ export function ShareLinksList({
               <Input
                 id={`downloads-${link.id}`}
                 min="1"
-                onChange={(event) => setMaxDownloadsDraft(event.target.value)}
+                onChange={(event) => {
+                  setMaxDownloadsDraft(event.target.value);
+                  if (formError) {
+                    setFormError(null);
+                  }
+                }}
                 placeholder="Leave empty for unlimited"
                 type="number"
                 value={maxDownloadsDraft}
               />
+              {formError ? (
+                <p
+                  className="text-xs text-destructive"
+                  data-testid={`share-link-error-${link.id}`}
+                  role="alert"
+                >
+                  {formError}
+                </p>
+              ) : null}
               <p className="text-xs text-muted-foreground">
                 Expiry cannot be changed after creation. Leave max downloads empty for unlimited.
                 The download limit applies to the whole link, not per visitor or per email. You also cannot set it below the number of downloads already used.
@@ -208,6 +241,7 @@ export function ShareLinksList({
                   onClick={() => {
                     setEditingLinkId(null);
                     setEmailDraft("");
+                    setFormError(null);
                     setMaxDownloadsDraft("");
                   }}
                   size="sm"
@@ -217,6 +251,7 @@ export function ShareLinksList({
                   Cancel
                 </Button>
                 <Button
+                  data-testid={`share-link-save-${link.id}`}
                   disabled={savingLinkId === link.id}
                   onClick={() => void handleSaveSettings(link)}
                   size="sm"

--- a/secure-vault/src/components/share/share-logout-button.tsx
+++ b/secure-vault/src/components/share/share-logout-button.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { LogOut } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+
+export function ShareLogoutButton({ token }: { token: string }) {
+  async function handleLogout() {
+    try {
+      const response = await fetch(`/api/share/${token}/logout`, {
+        method: "POST",
+      });
+
+      if (!response.ok) {
+        const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(payload?.error ?? "Failed to sign out from this link");
+      }
+
+      window.location.assign(`/s/${token}`);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to sign out from this link");
+    }
+  }
+
+  return (
+    <Button onClick={() => void handleLogout()} size="sm" type="button" variant="ghost">
+      <LogOut className="mr-2 size-4" />
+      Sign out
+    </Button>
+  );
+}

--- a/secure-vault/src/components/share/shared-download-button.tsx
+++ b/secure-vault/src/components/share/shared-download-button.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import * as React from "react";
+import { DownloadIcon, LoaderCircle } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+
+type SharedDownloadButtonProps = {
+  fileName?: string;
+  href: string;
+};
+
+function getDownloadFilename(response: Response, fallbackName?: string) {
+  const contentDisposition = response.headers.get("content-disposition");
+  const utf8Match = contentDisposition?.match(/filename\*=UTF-8''([^;]+)/i);
+
+  if (utf8Match?.[1]) {
+    return decodeURIComponent(utf8Match[1]);
+  }
+
+  const asciiMatch = contentDisposition?.match(/filename="([^"]+)"/i);
+  if (asciiMatch?.[1]) {
+    return asciiMatch[1];
+  }
+
+  return fallbackName ?? "download";
+}
+
+export function SharedDownloadButton({ fileName, href }: SharedDownloadButtonProps) {
+  const [isPending, setIsPending] = React.useState(false);
+  const objectUrlRef = React.useRef<string | null>(null);
+
+  React.useEffect(() => {
+    return () => {
+      if (objectUrlRef.current) {
+        URL.revokeObjectURL(objectUrlRef.current);
+        objectUrlRef.current = null;
+      }
+    };
+  }, []);
+
+  async function handleDownload() {
+    if (isPending) {
+      return;
+    }
+
+    setIsPending(true);
+
+    try {
+      const response = await fetch(href, {
+        credentials: "same-origin",
+      });
+
+      if (!response.ok) {
+        const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(payload?.error ?? "Failed to download file");
+      }
+
+      const blob = await response.blob();
+      const objectUrl = URL.createObjectURL(blob);
+      if (objectUrlRef.current) {
+        URL.revokeObjectURL(objectUrlRef.current);
+      }
+      objectUrlRef.current = objectUrl;
+      const anchor = document.createElement("a");
+
+      anchor.href = objectUrl;
+      anchor.download = getDownloadFilename(response, fileName);
+      anchor.rel = "noopener";
+      anchor.style.display = "none";
+      document.body.append(anchor);
+      window.requestAnimationFrame(() => {
+        anchor.click();
+        anchor.remove();
+      });
+
+      window.setTimeout(() => {
+        if (objectUrlRef.current === objectUrl) {
+          URL.revokeObjectURL(objectUrl);
+          objectUrlRef.current = null;
+        }
+      }, 60_000);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to download file");
+    } finally {
+      setIsPending(false);
+    }
+  }
+
+  return (
+    <Button
+      disabled={isPending}
+      onClick={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        void handleDownload();
+      }}
+      type="button"
+    >
+      {isPending ? <LoaderCircle className="mr-2 size-4 animate-spin" /> : <DownloadIcon className="mr-2 size-4" />}
+      {isPending ? "Downloading..." : "Download"}
+    </Button>
+  );
+}

--- a/secure-vault/src/components/share/shared-file-view.tsx
+++ b/secure-vault/src/components/share/shared-file-view.tsx
@@ -29,6 +29,7 @@ export function SharedFileView({
 
   return (
     <div
+      data-testid="shared-file-view"
       className={`flex w-full flex-col bg-muted/20 ${
         embedded ? "min-h-0 flex-1 overflow-hidden" : "h-dvh overflow-hidden"
       }`}
@@ -67,12 +68,14 @@ export function SharedFileView({
               <img
                 alt={fileName ?? "Shared file preview"}
                 className="block h-auto max-h-full w-auto max-w-full object-contain"
+                data-testid="shared-preview-image"
                 src={previewUrl}
               />
             </div>
           ) : (
             <iframe
               className="h-full w-full border-0"
+              data-testid="shared-preview-frame"
               src={previewUrl}
               title="File Preview"
             />

--- a/secure-vault/src/components/share/shared-file-view.tsx
+++ b/secure-vault/src/components/share/shared-file-view.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { FileIcon } from "lucide-react";
+
+import { SharedDownloadButton } from "@/components/share/shared-download-button";
+import { ShareLogoutButton } from "@/components/share/share-logout-button";
+import { canPreviewMime } from "@/lib/files/preview";
+
+export function SharedFileView({
+  embedded = false,
+  email,
+  fileId,
+  fileName,
+  mimeType,
+  token,
+}: {
+  embedded?: boolean;
+  email: string | null;
+  fileId?: string;
+  fileName?: string;
+  mimeType?: string;
+  token: string;
+}) {
+  const fileQuery = fileId ? `?fileId=${encodeURIComponent(fileId)}` : "";
+  const downloadUrl = `/api/share/${token}/download${fileQuery}`;
+  const previewUrl = `/api/share/${token}/preview${fileQuery}`;
+  const isImage = Boolean(mimeType && mimeType.startsWith("image/"));
+  const canPreview = mimeType ? canPreviewMime(mimeType) : true;
+
+  return (
+    <div
+      className={`flex w-full flex-col bg-muted/20 ${
+        embedded ? "min-h-0 flex-1 overflow-hidden" : "h-dvh overflow-hidden"
+      }`}
+    >
+      <header className="flex h-14 items-center justify-between border-b bg-background px-4">
+        <div className="flex items-center gap-2 font-medium">
+          <FileIcon className="size-5 text-muted-foreground" />
+          Secure Share
+        </div>
+        <div className="hidden items-center gap-2 border-l pl-4 opacity-75 sm:flex">
+          {email ? <span className="text-sm">Verified as {email}</span> : null}
+        </div>
+        <div className="flex items-center gap-2">
+          {email ? <ShareLogoutButton token={token} /> : null}
+          <SharedDownloadButton fileName={fileName} href={downloadUrl} />
+        </div>
+      </header>
+      <main className="flex min-h-0 flex-1 items-center justify-center overflow-hidden p-3 sm:p-4">
+        <div
+          className={`flex w-full max-w-5xl items-center justify-center overflow-hidden rounded-lg border bg-background shadow-sm ${
+            embedded ? "h-full min-h-0" : "h-full"
+          }`}
+        >
+          {!canPreview ? (
+            <div className="px-6 text-center text-sm text-muted-foreground">
+              Preview is not supported for this file type. Use download instead.
+            </div>
+          ) : isImage ? (
+            <div
+              className={`flex w-full items-center justify-center overflow-hidden bg-muted/20 ${
+                embedded
+                  ? "h-full min-h-0"
+                  : "h-[calc(100dvh-7rem)] sm:h-[calc(100dvh-8rem)]"
+              }`}
+            >
+              <img
+                alt={fileName ?? "Shared file preview"}
+                className="block h-auto max-h-full w-auto max-w-full object-contain"
+                src={previewUrl}
+              />
+            </div>
+          ) : (
+            <iframe
+              className="h-full w-full border-0"
+              src={previewUrl}
+              title="File Preview"
+            />
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/secure-vault/src/components/share/shared-folder-view.tsx
+++ b/secure-vault/src/components/share/shared-folder-view.tsx
@@ -94,6 +94,7 @@ export function SharedFolderView({
             <React.Fragment key={item.id}>
               <button
                 className="transition-colors hover:text-foreground"
+                data-testid={`shared-breadcrumb-${item.id}`}
                 onClick={() => setCurrentFolderId(item.id)}
                 type="button"
               >
@@ -121,6 +122,7 @@ export function SharedFolderView({
                 {data?.folders.map((folder) => (
                   <tr
                     className="cursor-pointer border-b hover:bg-muted/20"
+                    data-testid={`shared-folder-row-${folder.id}`}
                     key={folder.id}
                     onClick={() => setCurrentFolderId(folder.id)}
                   >
@@ -140,6 +142,7 @@ export function SharedFolderView({
                   <tr className="border-b hover:bg-muted/20" key={file.id}>
                     <td
                       className="cursor-pointer px-4 py-3"
+                      data-testid={`shared-file-row-${file.id}`}
                       onClick={() => setViewingFile(file)}
                     >
                       <div className="flex items-center gap-2">

--- a/secure-vault/src/components/share/shared-folder-view.tsx
+++ b/secure-vault/src/components/share/shared-folder-view.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import * as React from "react";
+import { useQuery } from "@tanstack/react-query";
+import { ChevronRight, FileIcon, FolderIcon } from "lucide-react";
+
+import { formatExplorerDate, formatFileSize } from "@/components/files/file-browser-utils";
+import { Button } from "@/components/ui/button";
+import { SharedDownloadButton } from "@/components/share/shared-download-button";
+import { SharedFileView } from "@/components/share/shared-file-view";
+import { ShareLogoutButton } from "@/components/share/share-logout-button";
+
+type SharedFolderResponse = {
+  breadcrumb: Array<{ id: string; name: string }>;
+  currentFolder: { id: string; name: string };
+  files: Array<{
+    id: string;
+    mimeType: string;
+    name: string;
+    size: number;
+    updatedAt: string;
+  }>;
+  folders: Array<{
+    id: string;
+    name: string;
+    updatedAt: string;
+  }>;
+};
+
+export function SharedFolderView({
+  email,
+  rootFolderId,
+  token,
+}: {
+  email: string | null;
+  rootFolderId: string;
+  token: string;
+}) {
+  const [currentFolderId, setCurrentFolderId] = React.useState(rootFolderId);
+  const [viewingFile, setViewingFile] = React.useState<SharedFolderResponse["files"][number] | null>(null);
+
+  const { data, isLoading } = useQuery<SharedFolderResponse>({
+    queryKey: ["shared-folder", token, currentFolderId],
+    queryFn: async () => {
+      const response = await fetch(
+        `/api/share/${token}/folder?folderId=${encodeURIComponent(currentFolderId)}`,
+      );
+
+      if (!response.ok) {
+        const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(payload?.error ?? "Failed to load folder");
+      }
+
+      return await response.json() as SharedFolderResponse;
+    },
+  });
+
+  if (viewingFile) {
+    return (
+      <div className="flex h-screen min-h-0 w-full flex-col">
+        <div className="border-b p-2">
+          <Button onClick={() => setViewingFile(null)} variant="ghost">
+            Back to directory
+          </Button>
+        </div>
+        <SharedFileView
+          embedded
+          email={email}
+          fileId={viewingFile.id}
+          fileName={viewingFile.name}
+          mimeType={viewingFile.mimeType}
+          token={token}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-screen w-full flex-col bg-muted/20">
+      <header className="flex h-14 items-center justify-between border-b bg-background px-4">
+        <div className="flex items-center gap-2 font-medium">
+          <FolderIcon className="size-5 text-muted-foreground" />
+          Secure Shared Folder
+        </div>
+        <div className="hidden items-center gap-2 border-l pl-4 opacity-75 sm:flex">
+          {email ? <span className="text-sm">Verified as {email}</span> : null}
+        </div>
+        {email ? <ShareLogoutButton token={token} /> : null}
+      </header>
+
+      <main className="flex-1 overflow-auto p-4">
+        <div className="mb-4 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+          {data?.breadcrumb.map((item, index) => (
+            <React.Fragment key={item.id}>
+              <button
+                className="transition-colors hover:text-foreground"
+                onClick={() => setCurrentFolderId(item.id)}
+                type="button"
+              >
+                {item.name}
+              </button>
+              {index < data.breadcrumb.length - 1 ? <ChevronRight className="size-4" /> : null}
+            </React.Fragment>
+          ))}
+        </div>
+
+        {isLoading ? (
+          <div>Loading...</div>
+        ) : (
+          <div className="relative h-full w-full overflow-hidden rounded-lg border bg-background">
+            <table className="w-full text-left text-sm">
+              <thead className="bg-muted/30">
+                <tr className="border-b">
+                  <th className="px-4 py-3 font-medium">Name</th>
+                  <th className="hidden px-4 py-3 font-medium md:table-cell">Size</th>
+                  <th className="hidden px-4 py-3 font-medium sm:table-cell">Modified</th>
+                  <th className="px-4 py-3 text-right font-medium">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data?.folders.map((folder) => (
+                  <tr
+                    className="cursor-pointer border-b hover:bg-muted/20"
+                    key={folder.id}
+                    onClick={() => setCurrentFolderId(folder.id)}
+                  >
+                    <td className="flex items-center gap-2 px-4 py-3">
+                      <FolderIcon className="size-4 text-amber-500/70" />
+                      {folder.name}
+                    </td>
+                    <td className="hidden px-4 py-3 md:table-cell">-</td>
+                    <td className="hidden px-4 py-3 sm:table-cell">
+                      {formatExplorerDate(folder.updatedAt)}
+                    </td>
+                    <td className="px-4 py-3 text-right" />
+                  </tr>
+                ))}
+
+                {data?.files.map((file) => (
+                  <tr className="border-b hover:bg-muted/20" key={file.id}>
+                    <td
+                      className="cursor-pointer px-4 py-3"
+                      onClick={() => setViewingFile(file)}
+                    >
+                      <div className="flex items-center gap-2">
+                        <FileIcon className="size-4 text-muted-foreground" />
+                        {file.name}
+                      </div>
+                    </td>
+                    <td className="hidden px-4 py-3 md:table-cell">{formatFileSize(file.size)}</td>
+                    <td className="hidden px-4 py-3 sm:table-cell">
+                      {formatExplorerDate(file.updatedAt)}
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <div className="flex justify-end">
+                        <SharedDownloadButton
+                          fileName={file.name}
+                          href={`/api/share/${token}/download?fileId=${file.id}`}
+                        />
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+
+                {data && data.folders.length === 0 && data.files.length === 0 ? (
+                  <tr>
+                    <td className="px-4 py-8 text-center text-muted-foreground" colSpan={4}>
+                      This folder is empty
+                    </td>
+                  </tr>
+                ) : null}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/secure-vault/src/lib/db/schema/sharing.ts
+++ b/secure-vault/src/lib/db/schema/sharing.ts
@@ -20,7 +20,7 @@ export const shareLinks = mysqlTable(
       .notNull()
       .references(() => users.id, { onDelete: "cascade", onUpdate: "cascade" }),
     token: varchar("token", { length: 255 }).notNull(),
-    expires_at: timestamp().notNull(),
+    expires_at: timestamp(),
     max_downloads: int(),
     download_count: int().default(0).notNull(),
     is_public: boolean().default(false).notNull(),
@@ -30,6 +30,7 @@ export const shareLinks = mysqlTable(
   (table) => [
     uniqueIndex("idx_share_links_token").on(table.token),
     index("idx_share_links_file_id").on(table.file_id),
+    index("idx_share_links_folder_id").on(table.folder_id),
   ],
 );
 
@@ -47,7 +48,9 @@ export const shareLinkOtps = mysqlTable("share_link_otps", {
   link_id: varchar("link_id", { length: 21 })
     .notNull()
     .references(() => shareLinks.id, { onDelete: "cascade", onUpdate: "cascade" }),
+  email: varchar("email", { length: 255 }).notNull(),
   otp_hash: varchar("otp_hash", { length: 255 }).notNull(),
+  attempt_count: int().default(0).notNull(),
   expires_at: timestamp().notNull(),
   used_at: timestamp(),
   created_at: timestamp().defaultNow().notNull(),
@@ -62,6 +65,7 @@ export const shareLinkAccessLogs = mysqlTable(
       .references(() => shareLinks.id, { onDelete: "cascade", onUpdate: "cascade" }),
     ip_address: varchar("ip_address", { length: 50 }).notNull(),
     user_agent: varchar("user_agent", { length: 255 }),
+    email: varchar("email", { length: 255 }),
     accessed_at: timestamp().defaultNow().notNull(),
   },
   (table) => [index("idx_access_logs_link_id").on(table.link_id)],

--- a/secure-vault/src/lib/email/index.ts
+++ b/secure-vault/src/lib/email/index.ts
@@ -1,0 +1,38 @@
+import { Resend } from "resend";
+import { otpEmailHtml } from "./templates";
+
+const resend = new Resend(process.env.RESEND_API_KEY!);
+const fromEmail = process.env.EMAIL_FROM || "onboarding@resend.dev"; // Fallback to resend default sandbox
+
+export async function sendEmail(to: string, subject: string, html: string) {
+  if (!process.env.RESEND_API_KEY) {
+    if (process.env.NODE_ENV !== "production") {
+      console.log(`[Email Suppressed in dev] To: ${to}, Subject: ${subject}`);
+      return;
+    }
+    throw new Error("RESEND_API_KEY is not configured");
+  }
+
+  const { error } = await resend.emails.send({
+    from: fromEmail,
+    to,
+    subject,
+    html,
+  });
+
+  if (error) {
+    throw new Error(`Email delivery failed: ${error.message}`);
+  }
+}
+
+export async function sendOTPEmail(to: string, code: string) {
+  if (process.env.NODE_ENV !== "production") {
+    console.log(
+      `[Share OTP][dev-only] To: ${to}, Code: ${code}. Resend is implemented but bypassed locally because it requires a verified sending domain.`,
+    );
+    return;
+  }
+
+  const html = otpEmailHtml(code);
+  await sendEmail(to, "Your secure access code", html);
+}

--- a/secure-vault/src/lib/email/templates.ts
+++ b/secure-vault/src/lib/email/templates.ts
@@ -1,0 +1,26 @@
+export function otpEmailHtml(code: string): string {
+  return `
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; line-height: 1.5; color: #333; }
+    .container { max-width: 600px; margin: 0 auto; padding: 20px; }
+    .otp-code { font-size: 32px; font-weight: bold; letter-spacing: 4px; padding: 20px; background-color: #f4f4f5; text-align: center; border-radius: 8px; margin: 20px 0; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
+    .footer { font-size: 12px; color: #666; margin-top: 40px; padding-top: 20px; border-top: 1px solid #eaeaea; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h2>SecureVault Access Code</h2>
+    <p>You requested a secure link access code. Please use the following code to continue:</p>
+    <div class="otp-code">${code}</div>
+    <p><strong>This code expires in 5 minutes.</strong></p>
+    <div class="footer">
+      If you did not request this code, you can safely ignore this email.
+    </div>
+  </div>
+</body>
+</html>
+  `;
+}

--- a/secure-vault/src/lib/sharing/otp-service.ts
+++ b/secure-vault/src/lib/sharing/otp-service.ts
@@ -1,0 +1,164 @@
+import { createHash, randomInt } from "node:crypto";
+
+import { and, desc, eq, isNull } from "drizzle-orm";
+import { nanoid } from "nanoid";
+
+import { sendOTPEmail } from "@/lib/email";
+import { MariadbConnection } from "@/lib/db";
+import { shareLinkEmails, shareLinkOtps } from "@/lib/db/schema";
+import { assertShareLinkAccessible, requireShareLinkByToken, ShareServiceError } from "@/lib/sharing/share-service";
+
+const OTP_TTL_MINUTES = 5;
+const OTP_LENGTH = 6;
+const MAX_OTP_ATTEMPTS = 3;
+
+export class OtpServiceError extends Error {
+  code: string;
+  status: number;
+
+  constructor(code: string, message: string, status: number) {
+    super(message);
+    this.name = "OtpServiceError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
+function normalizeEmail(email: string) {
+  return email.trim().toLowerCase();
+}
+
+export function generateOtpCode(): string {
+  return randomInt(0, 10 ** OTP_LENGTH).toString().padStart(OTP_LENGTH, "0");
+}
+
+export function hashOtp(code: string): string {
+  return createHash("sha256").update(code).digest("hex");
+}
+
+export async function createAndSendOtp({ email, token }: { email: string; token: string }) {
+  const normalizedEmail = normalizeEmail(email);
+  const link = await requireShareLinkByToken(token);
+  assertShareLinkAccessible(link);
+
+  if (link.is_public || link.allowedEmails.length === 0) {
+    throw new OtpServiceError("OTP_NOT_REQUIRED", "OTP is not required for this link", 400);
+  }
+
+  const db = MariadbConnection.getConnection();
+  const [allowedEmail] = await db
+    .select({ email: shareLinkEmails.email })
+    .from(shareLinkEmails)
+    .where(and(eq(shareLinkEmails.link_id, link.id), eq(shareLinkEmails.email, normalizedEmail)))
+    .limit(1);
+
+  if (!allowedEmail) {
+    throw new OtpServiceError("EMAIL_NOT_ALLOWED", "If the email is allowed, a code has been sent.", 200);
+  }
+
+  const otpId = nanoid();
+  const expiresAt = new Date(Date.now() + OTP_TTL_MINUTES * 60 * 1000);
+  const code = generateOtpCode();
+
+  await db.insert(shareLinkOtps).values({
+    attempt_count: 0,
+    email: normalizedEmail,
+    expires_at: expiresAt,
+    id: otpId,
+    link_id: link.id,
+    otp_hash: hashOtp(code),
+  });
+
+  try {
+    await sendOTPEmail(normalizedEmail, code);
+  } catch (error) {
+    await db
+      .update(shareLinkOtps)
+      .set({ used_at: new Date() })
+      .where(eq(shareLinkOtps.id, otpId));
+
+    console.error("Share OTP delivery failed", error);
+    throw new OtpServiceError("DELIVERY_FAILED", "Failed to deliver verification code", 503);
+  }
+
+  await db
+    .update(shareLinkOtps)
+    .set({ used_at: new Date() })
+    .where(
+      and(
+        eq(shareLinkOtps.link_id, link.id),
+        eq(shareLinkOtps.email, normalizedEmail),
+        isNull(shareLinkOtps.used_at),
+      ),
+    );
+
+  await db
+    .update(shareLinkOtps)
+    .set({ used_at: null })
+    .where(eq(shareLinkOtps.id, otpId));
+}
+
+export async function verifyOtp(input: { code: string; email: string; token: string }) {
+  const normalizedEmail = normalizeEmail(input.email);
+
+  if (!/^\d{6}$/.test(input.code)) {
+    throw new OtpServiceError("OTP_INVALID", "Verification code must be 6 digits", 400);
+  }
+
+  const link = await requireShareLinkByToken(input.token);
+  assertShareLinkAccessible(link);
+
+  const db = MariadbConnection.getConnection();
+  const [otpRow] = await db
+    .select()
+    .from(shareLinkOtps)
+    .where(
+      and(
+        eq(shareLinkOtps.link_id, link.id),
+        eq(shareLinkOtps.email, normalizedEmail),
+        isNull(shareLinkOtps.used_at),
+      ),
+    )
+    .orderBy(desc(shareLinkOtps.created_at))
+    .limit(1);
+
+  if (!otpRow) {
+    throw new OtpServiceError("OTP_NOT_FOUND", "Please request a new verification code", 403);
+  }
+
+  if (otpRow.expires_at < new Date()) {
+    throw new OtpServiceError("OTP_EXPIRED", "Verification code has expired", 403);
+  }
+
+  if (otpRow.attempt_count >= MAX_OTP_ATTEMPTS) {
+    throw new OtpServiceError(
+      "OTP_LOCKED",
+      "Too many attempts. Please request a new verification code",
+      403,
+    );
+  }
+
+  if (otpRow.otp_hash !== hashOtp(input.code)) {
+    await db
+      .update(shareLinkOtps)
+      .set({ attempt_count: otpRow.attempt_count + 1 })
+      .where(eq(shareLinkOtps.id, otpRow.id));
+
+    throw new OtpServiceError("OTP_INVALID", "Invalid verification code", 403);
+  }
+
+  await db
+    .update(shareLinkOtps)
+    .set({ used_at: new Date() })
+    .where(eq(shareLinkOtps.id, otpRow.id));
+
+  return {
+    email: normalizedEmail,
+    linkId: link.id,
+    linkExpiresAt: link.expires_at,
+  };
+}
+
+export function isShareOrOtpError(error: unknown): error is ShareServiceError | OtpServiceError {
+  return error instanceof ShareServiceError || error instanceof OtpServiceError;
+}

--- a/secure-vault/src/lib/sharing/otp-service.ts
+++ b/secure-vault/src/lib/sharing/otp-service.ts
@@ -139,10 +139,20 @@ export async function verifyOtp(input: { code: string; email: string; token: str
   }
 
   if (otpRow.otp_hash !== hashOtp(input.code)) {
+    const nextAttemptCount = otpRow.attempt_count + 1;
+
     await db
       .update(shareLinkOtps)
-      .set({ attempt_count: otpRow.attempt_count + 1 })
+      .set({ attempt_count: nextAttemptCount })
       .where(eq(shareLinkOtps.id, otpRow.id));
+
+    if (nextAttemptCount >= MAX_OTP_ATTEMPTS) {
+      throw new OtpServiceError(
+        "OTP_LOCKED",
+        "Too many attempts. Please request a new verification code",
+        403,
+      );
+    }
 
     throw new OtpServiceError("OTP_INVALID", "Invalid verification code", 403);
   }

--- a/secure-vault/src/lib/sharing/share-access-session.ts
+++ b/secure-vault/src/lib/sharing/share-access-session.ts
@@ -41,7 +41,6 @@ export async function createShareAccessSession(input: {
 
   cookieStore.set({
     expires: input.expiresAt,
-    httpOnly: true,
     name: getCookieName(input.linkId),
     ...getShareAccessCookieOptions(),
     value: encrypt(Buffer.from(JSON.stringify(session), "utf-8"), getMasterKey()).toString("hex"),

--- a/secure-vault/src/lib/sharing/share-access-session.ts
+++ b/secure-vault/src/lib/sharing/share-access-session.ts
@@ -1,0 +1,102 @@
+import { cookies } from "next/headers";
+
+import { decrypt, encrypt } from "@/lib/crypto/aes";
+import { AUTH_COOKIE_SECURE } from "@/lib/auth/cookies";
+import { getMasterKey } from "@/lib/crypto/keys";
+import { assertShareLinkAccessible, getShareLinkByToken } from "@/lib/sharing/share-service";
+
+export type ShareAccessSession = {
+  email: string;
+  expiresAt: string;
+  linkId: string;
+  verifiedAt: string;
+};
+
+function getCookieName(linkId: string) {
+  return `${AUTH_COOKIE_SECURE ? "__Secure-" : ""}share-${linkId}`;
+}
+
+function getShareAccessCookieOptions(maxAge?: number) {
+  return {
+    httpOnly: true as const,
+    maxAge,
+    path: "/",
+    sameSite: "lax" as const,
+    secure: AUTH_COOKIE_SECURE,
+  };
+}
+
+export async function createShareAccessSession(input: {
+  email: string;
+  expiresAt: Date;
+  linkId: string;
+}) {
+  const cookieStore = await cookies();
+  const session: ShareAccessSession = {
+    email: input.email,
+    expiresAt: input.expiresAt.toISOString(),
+    linkId: input.linkId,
+    verifiedAt: new Date().toISOString(),
+  };
+
+  cookieStore.set({
+    expires: input.expiresAt,
+    httpOnly: true,
+    name: getCookieName(input.linkId),
+    ...getShareAccessCookieOptions(),
+    value: encrypt(Buffer.from(JSON.stringify(session), "utf-8"), getMasterKey()).toString("hex"),
+  });
+}
+
+export async function readShareAccessSession(linkId: string) {
+  const cookieStore = await cookies();
+  const cookieValue = cookieStore.get(getCookieName(linkId))?.value;
+
+  if (!cookieValue) {
+    return null;
+  }
+
+  try {
+    const decryptedPayload = decrypt(Buffer.from(cookieValue, "hex"), getMasterKey());
+    const session = JSON.parse(decryptedPayload.toString("utf-8")) as ShareAccessSession;
+
+    if (session.linkId !== linkId) {
+      return null;
+    }
+
+    if (new Date(session.expiresAt) < new Date()) {
+      return null;
+    }
+
+    return session;
+  } catch {
+    return null;
+  }
+}
+
+export async function requireValidShareAccessSession(input: { linkId: string; token: string }) {
+  const session = await readShareAccessSession(input.linkId);
+
+  if (!session) {
+    return null;
+  }
+
+  const link = await getShareLinkByToken(input.token);
+
+  if (!link || link.id !== input.linkId) {
+    return null;
+  }
+
+  try {
+    assertShareLinkAccessible(link);
+  } catch {
+    return null;
+  }
+
+  return session;
+}
+
+export async function clearShareAccessSession(linkId: string) {
+  const cookieStore = await cookies();
+  cookieStore.set(getCookieName(linkId), "", getShareAccessCookieOptions(0));
+}

--- a/secure-vault/src/lib/sharing/share-service.ts
+++ b/secure-vault/src/lib/sharing/share-service.ts
@@ -60,7 +60,7 @@ function getAffectedCount(result: unknown) {
 }
 
 function normalizeEmails(emails: string[]) {
-  return [...new Set(emails.map((email) => email.trim().toLowerCase()).filter(Boolean))];
+  return [...new Set(emails.map((email) => email.trim().toLowerCase()).filter(Boolean))].sort();
 }
 
 export class ShareServiceError extends Error {
@@ -213,7 +213,7 @@ export async function getShareLinkByToken(token: string): Promise<ShareLinkRecor
 
   return {
     ...link,
-    allowedEmails: emails.map((item) => item.email),
+    allowedEmails: emails.map((item) => item.email).sort(),
     targetId: link.file_id ?? link.folder_id ?? "",
     targetType: link.file_id ? "file" : "folder",
   };
@@ -293,7 +293,7 @@ export async function listShareLinksForOwner(input: {
 
   return links.map((link) => ({
     ...link,
-    allowedEmails: emailsByLinkId.get(link.id) ?? [],
+    allowedEmails: [...(emailsByLinkId.get(link.id) ?? [])].sort(),
     targetId: link.file_id ?? link.folder_id,
     targetType: link.file_id ? ("file" as const) : ("folder" as const),
   }));
@@ -380,7 +380,7 @@ export async function updateShareLinkSettings(input: {
 
   return {
     ...link,
-    allowedEmails: emails.map((entry) => entry.email),
+    allowedEmails: emails.map((entry) => entry.email).sort(),
     targetId: link.file_id ?? link.folder_id,
     targetType: link.file_id ? ("file" as const) : ("folder" as const),
   };

--- a/secure-vault/src/lib/sharing/share-service.ts
+++ b/secure-vault/src/lib/sharing/share-service.ts
@@ -1,0 +1,697 @@
+import { and, desc, eq, inArray, isNull, or, sql } from "drizzle-orm";
+import { nanoid } from "nanoid";
+
+import { MariadbConnection } from "@/lib/db";
+import {
+  files,
+  folders,
+  shareLinkAccessLogs,
+  shareLinkEmails,
+  shareLinks,
+} from "@/lib/db/schema";
+
+type CreateShareLinkInput = {
+  createdBy: string;
+  fileId?: string;
+  folderId?: string;
+  expiresAt: Date | null;
+  maxDownloads: number | null;
+  allowedEmails: string[];
+};
+
+type ShareLinkRow = typeof shareLinks.$inferSelect;
+
+export type ShareLinkRecord = ShareLinkRow & {
+  allowedEmails: string[];
+  targetId: string;
+  targetType: "file" | "folder";
+};
+
+export type SharedFolderContents = {
+  breadcrumb: Array<{ id: string; name: string }>;
+  currentFolder: { id: string; name: string };
+  files: Array<{
+    id: string;
+    mimeType: string;
+    name: string;
+    size: number;
+    updatedAt: Date;
+  }>;
+  folders: Array<{
+    id: string;
+    name: string;
+    updatedAt: Date;
+  }>;
+};
+
+export type SharedFileSummary = {
+  id: string;
+  mimeType: string;
+  name: string;
+};
+
+function getAffectedCount(result: unknown) {
+  if (!result || typeof result !== "object") {
+    return 0;
+  }
+
+  const candidate = result as { affectedRows?: number; rowsAffected?: number };
+  return candidate.rowsAffected ?? candidate.affectedRows ?? 0;
+}
+
+function normalizeEmails(emails: string[]) {
+  return [...new Set(emails.map((email) => email.trim().toLowerCase()).filter(Boolean))];
+}
+
+export class ShareServiceError extends Error {
+  code: string;
+  status: number;
+
+  constructor(code: string, message: string, status: number) {
+    super(message);
+    this.name = "ShareServiceError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
+function createLinkNotFoundError() {
+  return new ShareServiceError("NOT_FOUND", "Share link not found", 404);
+}
+
+function createExpiredError() {
+  return new ShareServiceError("EXPIRED", "Share link is expired", 410);
+}
+
+function createDownloadLimitError() {
+  return new ShareServiceError("DOWNLOAD_LIMIT_REACHED", "Download limit reached", 403);
+}
+
+function createInvalidDownloadLimitError() {
+  return new ShareServiceError(
+    "INVALID_DOWNLOAD_LIMIT",
+    "Max downloads cannot be lower than the current download count",
+    400,
+  );
+}
+
+export async function createShareLink(input: CreateShareLinkInput) {
+  const { createdBy, expiresAt, fileId, folderId, maxDownloads } = input;
+
+  if (fileId && folderId) {
+    throw new ShareServiceError(
+      "INVALID_TARGET",
+      "Cannot share both a file and a folder in the same link",
+      400,
+    );
+  }
+
+  if (!fileId && !folderId) {
+    throw new ShareServiceError(
+      "INVALID_TARGET",
+      "Must specify either a fileId or folderId to share",
+      400,
+    );
+  }
+
+  const db = MariadbConnection.getConnection();
+
+  if (fileId) {
+    const [file] = await db
+      .select({ id: files.id })
+      .from(files)
+      .where(
+        and(
+          eq(files.id, fileId),
+          eq(files.user_id, createdBy),
+          eq(files.status, "ready"),
+          isNull(files.deleted_at),
+        ),
+      )
+      .limit(1);
+
+    if (!file) {
+      throw new ShareServiceError("TARGET_NOT_FOUND", "File not found", 404);
+    }
+  }
+
+  if (folderId) {
+    const [folder] = await db
+      .select({ id: folders.id })
+      .from(folders)
+      .where(
+        and(
+          eq(folders.id, folderId),
+          eq(folders.user_id, createdBy),
+          isNull(folders.deleted_at),
+        ),
+      )
+      .limit(1);
+
+    if (!folder) {
+      throw new ShareServiceError("TARGET_NOT_FOUND", "Folder not found", 404);
+    }
+  }
+
+  const allowedEmails = normalizeEmails(input.allowedEmails);
+  const isPublic = allowedEmails.length === 0;
+  const id = nanoid();
+  const token = nanoid(32);
+
+  await db.transaction(async (tx) => {
+    await tx.insert(shareLinks).values({
+      created_by: createdBy,
+      download_count: 0,
+      expires_at: expiresAt,
+      file_id: fileId ?? null,
+      folder_id: folderId ?? null,
+      id,
+      is_public: isPublic,
+      max_downloads: maxDownloads,
+      token,
+    });
+
+    if (allowedEmails.length > 0) {
+      await tx.insert(shareLinkEmails).values(
+        allowedEmails.map((email) => ({
+          email,
+          id: nanoid(),
+          link_id: id,
+        })),
+      );
+    }
+  });
+
+  return {
+    allowedEmails,
+    downloadCount: 0,
+    expiresAt,
+    id,
+    isPublic,
+    maxDownloads,
+    token,
+    url: `/s/${token}`,
+  };
+}
+
+export async function getShareLinkByToken(token: string): Promise<ShareLinkRecord | null> {
+  const db = MariadbConnection.getConnection();
+  const [link] = await db
+    .select()
+    .from(shareLinks)
+    .where(eq(shareLinks.token, token))
+    .limit(1);
+
+  if (!link) {
+    return null;
+  }
+
+  const emails = await db
+    .select({ email: shareLinkEmails.email })
+    .from(shareLinkEmails)
+    .where(eq(shareLinkEmails.link_id, link.id));
+
+  return {
+    ...link,
+    allowedEmails: emails.map((item) => item.email),
+    targetId: link.file_id ?? link.folder_id ?? "",
+    targetType: link.file_id ? "file" : "folder",
+  };
+}
+
+export async function requireShareLinkByToken(token: string): Promise<ShareLinkRecord> {
+  const link = await getShareLinkByToken(token);
+
+  if (!link) {
+    throw createLinkNotFoundError();
+  }
+
+  return link;
+}
+
+export function assertShareLinkAccessible(link: {
+  expires_at: Date | null;
+  revoked_at: Date | null;
+}) {
+  if (link.revoked_at) {
+    throw createLinkNotFoundError();
+  }
+
+  if (link.expires_at && link.expires_at < new Date()) {
+    throw createExpiredError();
+  }
+}
+
+export async function listShareLinksForOwner(input: {
+  ownerId: string;
+  fileId?: string;
+  folderId?: string;
+}) {
+  const { fileId, folderId, ownerId } = input;
+
+  if (fileId && folderId) {
+    throw new ShareServiceError("INVALID_TARGET", "Cannot query both a file and a folder", 400);
+  }
+
+  if (!fileId && !folderId) {
+    throw new ShareServiceError("INVALID_TARGET", "Must specify either a fileId or folderId", 400);
+  }
+
+  const db = MariadbConnection.getConnection();
+  const predicates = [eq(shareLinks.created_by, ownerId), isNull(shareLinks.revoked_at)];
+
+  if (fileId) {
+    predicates.push(eq(shareLinks.file_id, fileId));
+  }
+
+  if (folderId) {
+    predicates.push(eq(shareLinks.folder_id, folderId));
+  }
+
+  const links = await db
+    .select()
+    .from(shareLinks)
+    .where(and(...predicates))
+    .orderBy(desc(shareLinks.created_at));
+
+  if (links.length === 0) {
+    return [];
+  }
+
+  const emails = await db
+    .select({ email: shareLinkEmails.email, linkId: shareLinkEmails.link_id })
+    .from(shareLinkEmails)
+    .where(inArray(shareLinkEmails.link_id, links.map((link) => link.id)));
+
+  const emailsByLinkId = new Map<string, string[]>();
+
+  for (const entry of emails) {
+    const current = emailsByLinkId.get(entry.linkId) ?? [];
+    current.push(entry.email);
+    emailsByLinkId.set(entry.linkId, current);
+  }
+
+  return links.map((link) => ({
+    ...link,
+    allowedEmails: emailsByLinkId.get(link.id) ?? [],
+    targetId: link.file_id ?? link.folder_id,
+    targetType: link.file_id ? ("file" as const) : ("folder" as const),
+  }));
+}
+
+export async function getShareLinkForOwnerById(input: {
+  id: string;
+  ownerId: string;
+}) {
+  const db = MariadbConnection.getConnection();
+  const [link] = await db
+    .select()
+    .from(shareLinks)
+    .where(and(eq(shareLinks.id, input.id), eq(shareLinks.created_by, input.ownerId)))
+    .limit(1);
+
+  if (!link) {
+    throw createLinkNotFoundError();
+  }
+
+  return link;
+}
+
+export async function updateShareLinkSettings(input: {
+  allowedEmails: string[];
+  id: string;
+  maxDownloads: number | null;
+  ownerId: string;
+}) {
+  const db = MariadbConnection.getConnection();
+  const allowedEmails = normalizeEmails(input.allowedEmails);
+  const [existingLink] = await db
+    .select({ download_count: shareLinks.download_count, id: shareLinks.id })
+    .from(shareLinks)
+    .where(
+      and(
+        eq(shareLinks.id, input.id),
+        eq(shareLinks.created_by, input.ownerId),
+        isNull(shareLinks.revoked_at),
+      ),
+    )
+    .limit(1);
+
+  if (!existingLink) {
+    throw createLinkNotFoundError();
+  }
+
+  if (input.maxDownloads !== null && input.maxDownloads < existingLink.download_count) {
+    throw createInvalidDownloadLimitError();
+  }
+
+  await db.transaction(async (tx) => {
+    await tx
+      .delete(shareLinkEmails)
+      .where(eq(shareLinkEmails.link_id, input.id));
+
+    await tx
+      .update(shareLinks)
+      .set({
+        is_public: allowedEmails.length === 0,
+        max_downloads: input.maxDownloads,
+      })
+      .where(eq(shareLinks.id, input.id));
+
+    if (allowedEmails.length > 0) {
+      await tx.insert(shareLinkEmails).values(
+        allowedEmails.map((email) => ({
+          email,
+          id: nanoid(),
+          link_id: input.id,
+        })),
+      );
+    }
+  });
+
+  const link = await getShareLinkForOwnerById({
+    id: input.id,
+    ownerId: input.ownerId,
+  });
+  const emails = await db
+    .select({ email: shareLinkEmails.email })
+    .from(shareLinkEmails)
+    .where(eq(shareLinkEmails.link_id, input.id));
+
+  return {
+    ...link,
+    allowedEmails: emails.map((entry) => entry.email),
+    targetId: link.file_id ?? link.folder_id,
+    targetType: link.file_id ? ("file" as const) : ("folder" as const),
+  };
+}
+
+export async function revokeShareLink({ id, ownerId }: { id: string; ownerId: string }) {
+  const db = MariadbConnection.getConnection();
+  const result = await db
+    .update(shareLinks)
+    .set({ revoked_at: new Date() })
+    .where(and(eq(shareLinks.id, id), eq(shareLinks.created_by, ownerId), isNull(shareLinks.revoked_at)));
+
+  if (getAffectedCount(result) === 0) {
+    const [existingLink] = await db
+      .select({ id: shareLinks.id })
+      .from(shareLinks)
+      .where(and(eq(shareLinks.id, id), eq(shareLinks.created_by, ownerId)))
+      .limit(1);
+
+    if (!existingLink) {
+      throw createLinkNotFoundError();
+    }
+  }
+}
+
+export async function recordShareAccess(input: {
+  email?: string | null;
+  ipAddress: string;
+  linkId: string;
+  userAgent?: string;
+}) {
+  const db = MariadbConnection.getConnection();
+
+  await db.insert(shareLinkAccessLogs).values({
+    email: input.email ?? null,
+    id: nanoid(),
+    ip_address: input.ipAddress,
+    link_id: input.linkId,
+    user_agent: input.userAgent ?? null,
+  });
+}
+
+export async function incrementDownloadCount(linkId: string) {
+  const db = MariadbConnection.getConnection();
+  const [before] = await db
+    .select({
+      downloadCount: shareLinks.download_count,
+      id: shareLinks.id,
+      maxDownloads: shareLinks.max_downloads,
+    })
+    .from(shareLinks)
+    .where(eq(shareLinks.id, linkId))
+    .limit(1);
+
+  if (!before) {
+    return false;
+  }
+
+  if (before.maxDownloads !== null && before.downloadCount >= before.maxDownloads) {
+    return false;
+  }
+
+  const result = await db
+    .update(shareLinks)
+    .set({
+      download_count: sql`${shareLinks.download_count} + 1`,
+    })
+    .where(
+      and(
+        eq(shareLinks.id, linkId),
+        or(
+          isNull(shareLinks.max_downloads),
+          sql`${shareLinks.download_count} < ${shareLinks.max_downloads}`,
+        ),
+      ),
+    );
+
+  if (getAffectedCount(result) > 0) {
+    return true;
+  }
+
+  const [after] = await db
+    .select({
+      downloadCount: shareLinks.download_count,
+      id: shareLinks.id,
+    })
+    .from(shareLinks)
+    .where(eq(shareLinks.id, linkId))
+    .limit(1);
+
+  return Boolean(after && after.downloadCount > before.downloadCount);
+}
+
+export async function assertDownloadAllowed(linkId: string) {
+  const canDownload = await incrementDownloadCount(linkId);
+
+  if (!canDownload) {
+    throw createDownloadLimitError();
+  }
+}
+
+export async function requireFolderShareTargetFile(options: {
+  fileId: string;
+  ownerId: string;
+  rootFolderId: string;
+}) {
+  const db = MariadbConnection.getConnection();
+  const [file] = await db
+    .select({
+      folderId: files.folder_id,
+      id: files.id,
+    })
+    .from(files)
+    .where(
+      and(
+        eq(files.id, options.fileId),
+        eq(files.user_id, options.ownerId),
+        eq(files.status, "ready"),
+        isNull(files.deleted_at),
+      ),
+    )
+    .limit(1);
+
+  if (!file?.folderId) {
+    throw createLinkNotFoundError();
+  }
+
+  const allowedFolderIds = await getFolderSubtreeIds(options.ownerId, options.rootFolderId);
+
+  if (!allowedFolderIds.has(file.folderId)) {
+    throw createLinkNotFoundError();
+  }
+
+  return file.id;
+}
+
+export async function requireSharedFileSummary(options: {
+  fileId: string;
+  ownerId: string;
+}): Promise<SharedFileSummary> {
+  const db = MariadbConnection.getConnection();
+  const [file] = await db
+    .select({
+      id: files.id,
+      mimeType: files.mime_type,
+      name: files.name,
+    })
+    .from(files)
+    .where(
+      and(
+        eq(files.id, options.fileId),
+        eq(files.user_id, options.ownerId),
+        eq(files.status, "ready"),
+        isNull(files.deleted_at),
+      ),
+    )
+    .limit(1);
+
+  if (!file) {
+    throw createLinkNotFoundError();
+  }
+
+  return file;
+}
+
+export async function requireSharedFolderContents(options: {
+  currentFolderId: string;
+  ownerId: string;
+  rootFolderId: string;
+}): Promise<SharedFolderContents> {
+  const db = MariadbConnection.getConnection();
+  const folderRecords = await db
+    .select({
+      createdAt: folders.created_at,
+      id: folders.id,
+      name: folders.name,
+      parentId: folders.parent_id,
+    })
+    .from(folders)
+    .where(and(eq(folders.user_id, options.ownerId), isNull(folders.deleted_at)));
+
+  const folderMap = new Map(folderRecords.map((folder) => [folder.id, folder]));
+  const rootFolder = folderMap.get(options.rootFolderId);
+  const currentFolder = folderMap.get(options.currentFolderId);
+
+  if (!rootFolder || !currentFolder) {
+    throw createLinkNotFoundError();
+  }
+
+  const allowedFolderIds = collectFolderSubtreeIds(options.rootFolderId, folderRecords);
+
+  if (!allowedFolderIds.has(options.currentFolderId)) {
+    throw createLinkNotFoundError();
+  }
+
+  const breadcrumb = buildBreadcrumb(options.rootFolderId, options.currentFolderId, folderMap);
+  const childFolders = folderRecords
+    .filter((folder) => folder.parentId === options.currentFolderId)
+    .map((folder) => ({
+      id: folder.id,
+      name: folder.name,
+      updatedAt: folder.createdAt,
+    }));
+
+  const childFiles = await db
+    .select({
+      id: files.id,
+      mimeType: files.mime_type,
+      name: files.name,
+      size: files.size,
+      updatedAt: files.updated_at,
+    })
+    .from(files)
+    .where(
+      and(
+        eq(files.user_id, options.ownerId),
+        eq(files.status, "ready"),
+        eq(files.folder_id, options.currentFolderId),
+        isNull(files.deleted_at),
+      ),
+    );
+
+  return {
+    breadcrumb,
+    currentFolder: {
+      id: currentFolder.id,
+      name: currentFolder.name,
+    },
+    files: childFiles,
+    folders: childFolders,
+  };
+}
+
+async function getFolderSubtreeIds(ownerId: string, rootFolderId: string) {
+  const db = MariadbConnection.getConnection();
+  const folderRecords = await db
+    .select({
+      id: folders.id,
+      parentId: folders.parent_id,
+    })
+    .from(folders)
+    .where(and(eq(folders.user_id, ownerId), isNull(folders.deleted_at)));
+
+  return collectFolderSubtreeIds(rootFolderId, folderRecords);
+}
+
+function collectFolderSubtreeIds(
+  rootFolderId: string,
+  folderRecords: Array<{ id: string; parentId: string | null }>,
+) {
+  const childIdsByParent = new Map<string, string[]>();
+
+  for (const folder of folderRecords) {
+    if (!folder.parentId) {
+      continue;
+    }
+
+    const current = childIdsByParent.get(folder.parentId) ?? [];
+    current.push(folder.id);
+    childIdsByParent.set(folder.parentId, current);
+  }
+
+  const visited = new Set<string>();
+  const toVisit = [rootFolderId];
+
+  while (toVisit.length > 0) {
+    const currentFolderId = toVisit.pop();
+
+    if (!currentFolderId || visited.has(currentFolderId)) {
+      continue;
+    }
+
+    visited.add(currentFolderId);
+
+    for (const childId of childIdsByParent.get(currentFolderId) ?? []) {
+      toVisit.push(childId);
+    }
+  }
+
+  return visited;
+}
+
+function buildBreadcrumb(
+  rootFolderId: string,
+  currentFolderId: string,
+  folderMap: Map<string, { id: string; name: string; parentId: string | null }>,
+) {
+  const breadcrumb: Array<{ id: string; name: string }> = [];
+  const seen = new Set<string>();
+  let cursor: string | null = currentFolderId;
+
+  while (cursor) {
+    if (seen.has(cursor)) {
+      throw createLinkNotFoundError();
+    }
+
+    seen.add(cursor);
+    const folder = folderMap.get(cursor);
+
+    if (!folder) {
+      throw createLinkNotFoundError();
+    }
+
+    breadcrumb.unshift({ id: folder.id, name: folder.name });
+
+    if (cursor === rootFolderId) {
+      return breadcrumb;
+    }
+
+    cursor = folder.parentId;
+  }
+
+  throw createLinkNotFoundError();
+}

--- a/secure-vault/src/proxy.ts
+++ b/secure-vault/src/proxy.ts
@@ -63,10 +63,10 @@ export const config = {
     "/settings/:path*",
     "/trash/:path*",
     "/chat/:path*",
-    "/shared/:path*",
+
     "/api/upload/:path*",
     "/api/files/:path*",
-    "/api/share/:path*",
+
     "/api/chat/:path*",
   ],
 };

--- a/secure-vault/tests/auth/proxy.test.ts
+++ b/secure-vault/tests/auth/proxy.test.ts
@@ -155,10 +155,8 @@ describe("proxy", () => {
       "/settings/:path*",
       "/trash/:path*",
       "/chat/:path*",
-      "/shared/:path*",
       "/api/upload/:path*",
       "/api/files/:path*",
-      "/api/share/:path*",
       "/api/chat/:path*",
     ]);
   });

--- a/secure-vault/tests/download/headers-config.test.ts
+++ b/secure-vault/tests/download/headers-config.test.ts
@@ -3,17 +3,29 @@ import { describe, expect, it } from "vitest";
 import nextConfig from "@/../next.config";
 
 describe("next config headers", () => {
-  it("keeps the preview route embeddable while the global app stays frame-denied", async () => {
+  it("keeps preview routes embeddable while the global app stays frame-denied", async () => {
     const headers = await nextConfig.headers?.();
 
     expect(headers).toBeDefined();
 
-    const previewRule = headers?.find((rule) => rule.source === "/api/files/:id/preview");
+    const filePreviewRule = headers?.find((rule) => rule.source === "/api/files/:id/preview");
+    const sharePreviewRule = headers?.find((rule) => rule.source === "/api/share/:token/preview");
     const globalRule = headers?.find(
-      (rule) => rule.source === "/((?!api/files/[^/]+/preview$).*)",
+      (rule) =>
+        rule.source === "/((?!api/files/[^/]+/preview$|api/share/[^/]+/preview$).*)",
     );
 
-    expect(previewRule?.headers).toEqual(
+    expect(filePreviewRule?.headers).toEqual(
+      expect.arrayContaining([
+        { key: "X-Frame-Options", value: "SAMEORIGIN" },
+        expect.objectContaining({
+          key: "Content-Security-Policy",
+          value: expect.stringContaining("frame-ancestors 'self'"),
+        }),
+      ]),
+    );
+
+    expect(sharePreviewRule?.headers).toEqual(
       expect.arrayContaining([
         { key: "X-Frame-Options", value: "SAMEORIGIN" },
         expect.objectContaining({

--- a/secure-vault/tests/e2e/file-actions.spec.ts
+++ b/secure-vault/tests/e2e/file-actions.spec.ts
@@ -73,12 +73,12 @@ async function uploadFiles(page: Page, fileNames: readonly string[]) {
   await page.locator('input[type="file"]').setInputFiles(filePaths);
 
   for (const fileName of fileNames) {
-    await expect(page.getByRole("dialog", { name: "Upload Files" })).toContainText(fileName, {
-      timeout: 120_000,
-    });
-    await expect(page.getByRole("dialog", { name: "Upload Files" })).toContainText("Done", {
-      timeout: 180_000,
-    });
+    const uploadRow = page
+      .locator(`[data-testid^="upload-row-"][data-test-file-name="${fileName}"]`)
+      .first();
+
+    await expect(uploadRow).toBeVisible({ timeout: 120_000 });
+    await expect(uploadRow).toContainText("Done", { timeout: 180_000 });
   }
 
   await page.keyboard.press("Escape");
@@ -87,10 +87,21 @@ async function uploadFiles(page: Page, fileNames: readonly string[]) {
 
 async function createFolder(page: Page, name: string) {
   await closeUploadDialogIfOpen(page);
+  const createFolderDialog = page.getByRole("dialog", { name: "Create folder" });
   await page.getByRole("button", { name: "New folder" }).click();
+  await expect(createFolderDialog).toBeVisible();
   await page.getByLabel("Folder name").fill(name);
-  await page.getByRole("button", { name: "Create folder" }).click();
+  const confirmButton = createFolderDialog.getByRole("button", { name: "Create folder", exact: true });
+  await expect(confirmButton).toBeEnabled();
+  await confirmButton.click();
+  await expect(createFolderDialog).toBeHidden();
+  await expect.poll(() => getGridFolderButton(page, name).count()).toBe(1);
   await expect(getGridFolderButton(page, name)).toBeVisible();
+}
+
+async function openGridFolder(page: Page, folderName: string) {
+  await getGridFolderButton(page, folderName).click();
+  await expect(getBreadcrumbFolderButton(page, folderName)).toBeVisible();
 }
 
 async function openFileActions(page: Page, fileName: string) {
@@ -235,7 +246,7 @@ test.describe("file actions", () => {
     await expect(page.getByText("File not found")).toHaveCount(0);
     await expect(getFileNameButton(page, "renamed-tiny.pdf")).toHaveCount(0);
 
-    await getGridFolderButton(page, "Projects").click();
+    await openGridFolder(page, "Projects");
     await expect(getFileNameButton(page, "renamed-tiny.pdf")).toBeVisible();
 
     await openFileActions(page, "renamed-tiny.pdf");
@@ -272,7 +283,7 @@ test.describe("file actions", () => {
     await expect(page.getByText("tiny.pdf", { exact: true })).toHaveCount(0);
     await expect(page.getByText("photo.png", { exact: true })).toHaveCount(0);
 
-    await getGridFolderButton(page, "Bulk Folder").click();
+    await openGridFolder(page, "Bulk Folder");
     await expect(page.getByText("tiny.pdf", { exact: true })).toBeVisible();
     await expect(page.getByText("photo.png", { exact: true })).toBeVisible();
 
@@ -308,7 +319,7 @@ test.describe("file actions", () => {
     await expect(getGridFolderButton(page, "Archives")).toBeVisible();
     await expect(getGridFolderButton(page, "Projects")).toHaveCount(0);
 
-    await getGridFolderButton(page, "Archives").click();
+    await openGridFolder(page, "Archives");
     await expect(page.getByRole("button", { name: "All files" })).toBeVisible();
     await expect(getGridFolderButton(page, "Archives")).toBeVisible();
     await expect(page.getByText("File not found")).toHaveCount(0);
@@ -322,9 +333,9 @@ test.describe("file actions", () => {
     await openUploadDialog(page);
 
     await createFolder(page, "Documents");
-    await getGridFolderButton(page, "Documents").click();
+    await openGridFolder(page, "Documents");
     await createFolder(page, "Taxes");
-    await getGridFolderButton(page, "Taxes").click();
+    await openGridFolder(page, "Taxes");
     await uploadFiles(page, ["tiny.pdf"]);
     await page.getByRole("button", { name: "All files" }).click();
     await openFileActions(page, "tiny.pdf");
@@ -365,9 +376,9 @@ test.describe("file actions", () => {
 
     await expect(getGridFolderButton(page, "Projects")).toHaveCount(0);
 
-    await getGridFolderButton(page, "Archive").click();
+    await openGridFolder(page, "Archive");
     await expect(getGridFolderButton(page, "Projects")).toBeVisible();
-    await getGridFolderButton(page, "Projects").click();
+    await openGridFolder(page, "Projects");
     await expect(page.getByRole("button", { name: "All files" })).toBeVisible();
     await expect(getBreadcrumbFolderButton(page, "Archive")).toBeVisible();
     await expect(getBreadcrumbFolderButton(page, "Projects")).toBeVisible();
@@ -382,7 +393,7 @@ test.describe("file actions", () => {
     await page.reload();
 
     await createFolder(page, "Temp");
-    await getGridFolderButton(page, "Temp").click();
+    await openGridFolder(page, "Temp");
 
     await chooseFolderAction(page, "Temp", "Delete");
     await page.getByRole("button", { name: "Delete folder" }).click();
@@ -401,7 +412,7 @@ test.describe("file actions", () => {
     await page.reload();
 
     await createFolder(page, "A");
-    await getGridFolderButton(page, "A").click();
+    await openGridFolder(page, "A");
     await createFolder(page, "B");
     await page.getByRole("button", { name: "All files" }).click();
 

--- a/secure-vault/tests/e2e/helpers/share.ts
+++ b/secure-vault/tests/e2e/helpers/share.ts
@@ -1,0 +1,374 @@
+import path from "node:path";
+
+import { and, desc, eq, isNull } from "drizzle-orm";
+import { expect, type Page } from "@playwright/test";
+import { nanoid } from "nanoid";
+
+import { createFolder, moveFile } from "../../../src/app/api/files/service";
+import { MariadbConnection } from "../../../src/lib/db";
+import {
+  files,
+  folders,
+  shareLinkAccessLogs,
+  shareLinkEmails,
+  shareLinkOtps,
+  shareLinks,
+  users,
+} from "../../../src/lib/db/schema";
+import { hashOtp } from "../../../src/lib/sharing/otp-service";
+import { createShareLink } from "../../../src/lib/sharing/share-service";
+import { markTestUserEmailVerified } from "./test-user-cleanup";
+import type { TestUserCredentials } from "./test-user";
+
+const SAMPLE_DIR = path.resolve(process.cwd(), "sample_upload_test_file");
+
+function normalizeEmail(email: string) {
+  return email.trim().toLowerCase();
+}
+
+export async function clearBrowserStorage(page: Page) {
+  try {
+    await page.evaluate(() => {
+      window.localStorage.clear();
+      window.sessionStorage.clear();
+    });
+  } catch {
+    // Ignore cleanup failures when there is no active page origin.
+  }
+
+  await page.context().clearCookies();
+}
+
+export async function signUpAndBypassVerification(
+  page: Page,
+  credentials: TestUserCredentials,
+) {
+  await page.goto("/signup");
+  await page.getByLabel("Name").fill(credentials.name);
+  await page.getByLabel("Email").fill(credentials.email);
+  await page.getByLabel("Password").fill(credentials.password);
+  await page.getByRole("button", { name: "Create an account" }).click();
+  await page.waitForURL("**/activity");
+
+  await markTestUserEmailVerified(credentials.email);
+}
+
+export async function openFilesPage(page: Page) {
+  await page.goto("/files");
+  await page.reload();
+}
+
+export async function ensureUploadDialogOpen(page: Page) {
+  const uploadDialog = page.getByRole("dialog", { name: "Upload Files" });
+
+  if (await uploadDialog.isVisible().catch(() => false)) {
+    return uploadDialog;
+  }
+
+  await page.getByRole("button", { name: "Upload files" }).click();
+  await expect(uploadDialog).toBeVisible();
+  return uploadDialog;
+}
+
+export async function uploadFiles(page: Page, fileNames: readonly string[]) {
+  const uploadDialog = await ensureUploadDialogOpen(page);
+  const filePaths = fileNames.map((fileName) => path.join(SAMPLE_DIR, fileName));
+
+  await page.locator('input[type="file"]').setInputFiles(filePaths);
+
+  for (const fileName of fileNames) {
+    const uploadRow = page
+      .locator(`[data-testid^="upload-row-"][data-test-file-name="${fileName}"]`)
+      .first();
+
+    await expect(uploadRow).toBeVisible({ timeout: 120_000 });
+    await expect(uploadRow).toContainText("Done", { timeout: 180_000 });
+  }
+
+  await page.keyboard.press("Escape");
+  await expect(uploadDialog).toBeHidden();
+}
+
+export async function createFolderViaUi(page: Page, name: string) {
+  await page.getByRole("button", { name: "New folder" }).click();
+  await page.getByLabel("Folder name").fill(name);
+  await page.getByRole("button", { name: "Create folder" }).click();
+}
+
+export async function getUserIdByEmail(email: string) {
+  const db = MariadbConnection.getConnection();
+  const [user] = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.email, normalizeEmail(email)))
+    .limit(1);
+
+  return user?.id ?? null;
+}
+
+export async function getFileIdForUser(userId: string, fileName: string) {
+  const db = MariadbConnection.getConnection();
+  const [file] = await db
+    .select({ id: files.id })
+    .from(files)
+    .where(
+      and(
+        eq(files.user_id, userId),
+        eq(files.name, fileName),
+        eq(files.status, "ready"),
+        isNull(files.deleted_at),
+      ),
+    )
+    .limit(1);
+
+  return file?.id ?? null;
+}
+
+export async function getFolderIdForUser(
+  userId: string,
+  folderName: string,
+  parentId?: string | null,
+) {
+  const predicates = [
+    eq(folders.user_id, userId),
+    eq(folders.name, folderName),
+    isNull(folders.deleted_at),
+  ];
+
+  if (parentId === null) {
+    predicates.push(isNull(folders.parent_id));
+  } else if (parentId) {
+    predicates.push(eq(folders.parent_id, parentId));
+  }
+
+  const db = MariadbConnection.getConnection();
+  const [folder] = await db
+    .select({ id: folders.id })
+    .from(folders)
+    .where(and(...predicates))
+    .limit(1);
+
+  return folder?.id ?? null;
+}
+
+export async function createFolderFixture(userId: string, name: string, parentId: string | null) {
+  return createFolder(userId, name, parentId);
+}
+
+export async function moveFileFixture(userId: string, fileId: string, folderId: string | null) {
+  return moveFile(userId, fileId, folderId);
+}
+
+export async function createShareLinkFixture(input: {
+  allowedEmails: string[];
+  createdBy: string;
+  expiresAt: Date | null;
+  fileId?: string;
+  folderId?: string;
+  maxDownloads: number | null;
+}) {
+  return createShareLink(input);
+}
+
+export async function getLatestShareLinkForTarget(input: {
+  ownerId: string;
+  fileId?: string;
+  folderId?: string;
+}) {
+  const db = MariadbConnection.getConnection();
+  const predicates = [eq(shareLinks.created_by, input.ownerId)];
+
+  if (input.fileId) {
+    predicates.push(eq(shareLinks.file_id, input.fileId));
+  }
+
+  if (input.folderId) {
+    predicates.push(eq(shareLinks.folder_id, input.folderId));
+  }
+
+  const [link] = await db
+    .select()
+    .from(shareLinks)
+    .where(and(...predicates))
+    .orderBy(desc(shareLinks.created_at))
+    .limit(1);
+
+  return link ?? null;
+}
+
+export async function waitForShareOtpRow(input: {
+  email: string;
+  linkId: string;
+  timeoutMs?: number;
+}) {
+  const startedAt = Date.now();
+  const timeoutMs = input.timeoutMs ?? 10_000;
+
+  while (Date.now() - startedAt < timeoutMs) {
+    const otpRow = await getLatestShareOtpRow(input.linkId, input.email);
+
+    if (otpRow) {
+      return otpRow;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+
+  throw new Error("Timed out waiting for share OTP row");
+}
+
+export async function getLatestShareOtpRow(linkId: string, email: string) {
+  const db = MariadbConnection.getConnection();
+  const [otpRow] = await db
+    .select()
+    .from(shareLinkOtps)
+    .where(
+      and(
+        eq(shareLinkOtps.link_id, linkId),
+        eq(shareLinkOtps.email, normalizeEmail(email)),
+      ),
+    )
+    .orderBy(desc(shareLinkOtps.created_at))
+    .limit(1);
+
+  return otpRow ?? null;
+}
+
+export async function expireLatestShareOtp(input: {
+  email: string;
+  expiresAt?: Date;
+  linkId: string;
+}) {
+  const otpRow = await getLatestShareOtpRow(input.linkId, input.email);
+
+  if (!otpRow) {
+    throw new Error("Share OTP row not found");
+  }
+
+  const db = MariadbConnection.getConnection();
+  await db
+    .update(shareLinkOtps)
+    .set({ expires_at: input.expiresAt ?? new Date(Date.now() - 60_000) })
+    .where(eq(shareLinkOtps.id, otpRow.id));
+}
+
+export async function setLatestShareOtpAttemptCount(input: {
+  attemptCount: number;
+  email: string;
+  linkId: string;
+}) {
+  const otpRow = await getLatestShareOtpRow(input.linkId, input.email);
+
+  if (!otpRow) {
+    throw new Error("Share OTP row not found");
+  }
+
+  const db = MariadbConnection.getConnection();
+  await db
+    .update(shareLinkOtps)
+    .set({ attempt_count: input.attemptCount })
+    .where(eq(shareLinkOtps.id, otpRow.id));
+}
+
+export async function seedKnownShareOtp(input: {
+  code: string;
+  email: string;
+  expiresAt?: Date;
+  linkId: string;
+}) {
+  const db = MariadbConnection.getConnection();
+  const normalizedEmail = normalizeEmail(input.email);
+  const expiresAt = input.expiresAt ?? new Date(Date.now() + 5 * 60 * 1000);
+
+  await db
+    .update(shareLinkOtps)
+    .set({ used_at: new Date() })
+    .where(
+      and(
+        eq(shareLinkOtps.link_id, input.linkId),
+        eq(shareLinkOtps.email, normalizedEmail),
+        isNull(shareLinkOtps.used_at),
+      ),
+    );
+
+  const id = nanoid();
+  await db.insert(shareLinkOtps).values({
+    attempt_count: 0,
+    created_at: new Date(),
+    email: normalizedEmail,
+    expires_at: expiresAt,
+    id,
+    link_id: input.linkId,
+    otp_hash: hashOtp(input.code),
+    used_at: null,
+  });
+
+  return id;
+}
+
+export async function revokeShareLinkFixture(linkId: string) {
+  const db = MariadbConnection.getConnection();
+  await db
+    .update(shareLinks)
+    .set({ revoked_at: new Date() })
+    .where(eq(shareLinks.id, linkId));
+}
+
+export async function expireShareLinkFixture(linkId: string, expiresAt?: Date) {
+  const db = MariadbConnection.getConnection();
+  await db
+    .update(shareLinks)
+    .set({ expires_at: expiresAt ?? new Date(Date.now() - 60_000) })
+    .where(eq(shareLinks.id, linkId));
+}
+
+export async function getShareLinkUsage(linkId: string) {
+  const db = MariadbConnection.getConnection();
+  const [link] = await db
+    .select({
+      downloadCount: shareLinks.download_count,
+      maxDownloads: shareLinks.max_downloads,
+      token: shareLinks.token,
+    })
+    .from(shareLinks)
+    .where(eq(shareLinks.id, linkId))
+    .limit(1);
+
+  return link ?? null;
+}
+
+export async function getShareLinkRecord(linkId: string) {
+  const db = MariadbConnection.getConnection();
+  const [link] = await db
+    .select()
+    .from(shareLinks)
+    .where(eq(shareLinks.id, linkId))
+    .limit(1);
+
+  return link ?? null;
+}
+
+export async function getShareAccessLogCount(linkId: string, email?: string) {
+  const db = MariadbConnection.getConnection();
+  const rows = await db
+    .select({ id: shareLinkAccessLogs.id })
+    .from(shareLinkAccessLogs)
+    .where(
+      and(
+        eq(shareLinkAccessLogs.link_id, linkId),
+        ...(email ? [eq(shareLinkAccessLogs.email, normalizeEmail(email))] : []),
+      ),
+    );
+
+  return rows.length;
+}
+
+export async function getAllowedEmailsForLink(linkId: string) {
+  const db = MariadbConnection.getConnection();
+  const rows = await db
+    .select({ email: shareLinkEmails.email })
+    .from(shareLinkEmails)
+    .where(eq(shareLinkEmails.link_id, linkId));
+
+  return rows.map((row) => row.email).sort();
+}

--- a/secure-vault/tests/e2e/share-access-logging.spec.ts
+++ b/secure-vault/tests/e2e/share-access-logging.spec.ts
@@ -1,0 +1,92 @@
+import { expect, test, type Browser } from "@playwright/test";
+
+import { buildTestUserCredentials } from "./helpers/test-user";
+import { cleanupTestUserByEmail } from "./helpers/test-user-cleanup";
+import {
+  clearBrowserStorage,
+  createShareLinkFixture,
+  getFileIdForUser,
+  getShareAccessLogCount,
+  getShareLinkUsage,
+  getUserIdByEmail,
+  openFilesPage,
+  seedKnownShareOtp,
+  signUpAndBypassVerification,
+  uploadFiles,
+  waitForShareOtpRow,
+} from "./helpers/share";
+
+async function createVisitorPage(browser: Browser) {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  return { context, page };
+}
+
+test.describe("share access logging", () => {
+  test.afterEach(async ({ page }, testInfo) => {
+    const { email } = buildTestUserCredentials(testInfo);
+
+    await clearBrowserStorage(page);
+    await cleanupTestUserByEmail(email);
+  });
+
+  test("records restricted unlocks and successful downloads", async ({ browser, page }, testInfo) => {
+    test.setTimeout(180_000);
+    const credentials = buildTestUserCredentials(testInfo);
+    const visitor = await createVisitorPage(browser);
+    const allowedEmail = "reader@example.com";
+
+    try {
+      await signUpAndBypassVerification(page, credentials);
+      await openFilesPage(page);
+      await uploadFiles(page, ["tiny.pdf"]);
+
+      const userId = await getUserIdByEmail(credentials.email);
+      expect(userId).not.toBeNull();
+      const fileId = await getFileIdForUser(userId!, "tiny.pdf");
+      expect(fileId).not.toBeNull();
+
+      const link = await createShareLinkFixture({
+        allowedEmails: [allowedEmail],
+        createdBy: userId!,
+        expiresAt: null,
+        fileId: fileId!,
+        maxDownloads: null,
+      });
+
+      await visitor.page.goto(`/s/${link.token}`);
+      await visitor.page.getByLabel("Email Address").fill(allowedEmail);
+      await visitor.page.getByRole("button", { name: "Send Verification Code" }).click();
+      await expect(visitor.page.getByLabel("Verification Code")).toBeVisible();
+
+      await waitForShareOtpRow({ email: allowedEmail, linkId: link.id });
+      await seedKnownShareOtp({ code: "123456", email: allowedEmail, linkId: link.id });
+
+      await visitor.page.getByLabel("Verification Code").fill("123456");
+      await visitor.page.getByRole("button", { name: "Verify and Access" }).click();
+      await expect(visitor.page.getByText(`Verified as ${allowedEmail}`)).toBeVisible();
+
+      await expect.poll(() => getShareAccessLogCount(link.id, allowedEmail)).toBeGreaterThan(0);
+
+      const downloadResult = await visitor.page.evaluate(async (href) => {
+        const response = await fetch(href, { credentials: "same-origin" });
+        const buffer = await response.arrayBuffer();
+
+        return {
+          byteLength: buffer.byteLength,
+          status: response.status,
+        };
+      }, `/api/share/${link.token}/download`);
+
+      expect(downloadResult.status).toBe(200);
+      expect(downloadResult.byteLength).toBeGreaterThan(0);
+
+      await expect.poll(async () => (await getShareLinkUsage(link.id))?.downloadCount ?? 0).toBe(1);
+      await expect.poll(async () => getShareAccessLogCount(link.id)).toBeGreaterThan(1);
+    } finally {
+      await clearBrowserStorage(visitor.page);
+      await visitor.context.close();
+    }
+  });
+});

--- a/secure-vault/tests/e2e/share-download-limits.spec.ts
+++ b/secure-vault/tests/e2e/share-download-limits.spec.ts
@@ -1,0 +1,112 @@
+import { expect, test, type Browser, type Page } from "@playwright/test";
+
+import { buildTestUserCredentials } from "./helpers/test-user";
+import { cleanupTestUserByEmail } from "./helpers/test-user-cleanup";
+import {
+  clearBrowserStorage,
+  createShareLinkFixture,
+  getFileIdForUser,
+  getLatestShareLinkForTarget,
+  getShareLinkUsage,
+  getUserIdByEmail,
+  openFilesPage,
+  signUpAndBypassVerification,
+  uploadFiles,
+} from "./helpers/share";
+
+async function createVisitorPage(browser: Browser) {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  return { context, page };
+}
+
+async function fetchSharedDownload(page: Page, token: string) {
+  return page.evaluate(async (shareToken) => {
+    const response = await fetch(`/api/share/${shareToken}/download`, {
+      credentials: "same-origin",
+    });
+
+    return {
+      body: await response.text(),
+      status: response.status,
+    };
+  }, token);
+}
+
+test.describe("share download limits", () => {
+  test.afterEach(async ({ page }, testInfo) => {
+    const { email } = buildTestUserCredentials(testInfo);
+
+    await clearBrowserStorage(page);
+    await cleanupTestUserByEmail(email);
+  });
+
+  test("enforces link-wide download limits and reflects them in owner UI", async ({
+    browser,
+    page,
+  }, testInfo) => {
+    test.setTimeout(180_000);
+    const credentials = buildTestUserCredentials(testInfo);
+    const visitor = await createVisitorPage(browser);
+
+    try {
+      await signUpAndBypassVerification(page, credentials);
+      await openFilesPage(page);
+      await uploadFiles(page, ["tiny.pdf"]);
+
+      const userId = await getUserIdByEmail(credentials.email);
+      expect(userId).not.toBeNull();
+      const fileId = await getFileIdForUser(userId!, "tiny.pdf");
+      expect(fileId).not.toBeNull();
+
+      const link = await createShareLinkFixture({
+        allowedEmails: [],
+        createdBy: userId!,
+        expiresAt: null,
+        fileId: fileId!,
+        maxDownloads: 2,
+      });
+
+      await visitor.page.goto(`/s/${link.token}`);
+      await expect(visitor.page.getByRole("button", { name: "Download" })).toBeVisible();
+
+      const firstDownload = await fetchSharedDownload(visitor.page, link.token);
+      expect(firstDownload.status).toBe(200);
+
+      const secondDownload = await fetchSharedDownload(visitor.page, link.token);
+      expect(secondDownload.status).toBe(200);
+
+      await expect.poll(async () => (await getShareLinkUsage(link.id))?.downloadCount ?? 0).toBe(2);
+
+      const thirdDownload = await fetchSharedDownload(visitor.page, link.token);
+      expect(thirdDownload.status).toBe(403);
+      expect(thirdDownload.body).toContain("Download limit reached");
+
+      await page.goto("/files");
+      await page.locator(`[data-testid^="file-actions-"][data-test-file-name="tiny.pdf"]`).first().click();
+      await page.getByRole("menuitem", { name: "Share" }).click();
+
+      const latestLink = await getLatestShareLinkForTarget({
+        fileId: fileId!,
+        ownerId: userId!,
+      });
+      expect(latestLink).not.toBeNull();
+
+      const shareRow = page.getByTestId(`share-link-row-${latestLink!.id}`);
+      await expect(shareRow).toContainText("Download limit reached: 2 used of 2");
+
+      await shareRow.getByTestId(`share-link-edit-${latestLink!.id}`).click();
+      await page.locator(`#downloads-${latestLink!.id}`).fill("4");
+      await shareRow.getByTestId(`share-link-save-${latestLink!.id}`).click();
+      await expect(shareRow).toContainText("Downloads used: 2 of 4");
+
+      const fourthDownload = await fetchSharedDownload(visitor.page, link.token);
+      expect(fourthDownload.status).toBe(200);
+      await expect.poll(async () => (await getShareLinkUsage(link.id))?.downloadCount ?? 0).toBe(3);
+    } finally {
+      await clearBrowserStorage(visitor.page);
+      await visitor.context.close();
+    }
+  });
+});

--- a/secure-vault/tests/e2e/share-folder.spec.ts
+++ b/secure-vault/tests/e2e/share-folder.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test, type Browser } from "@playwright/test";
+
+import { buildTestUserCredentials } from "./helpers/test-user";
+import { cleanupTestUserByEmail } from "./helpers/test-user-cleanup";
+import {
+  clearBrowserStorage,
+  createFolderFixture,
+  createShareLinkFixture,
+  getFileIdForUser,
+  getUserIdByEmail,
+  openFilesPage,
+  moveFileFixture,
+  signUpAndBypassVerification,
+  uploadFiles,
+} from "./helpers/share";
+
+async function createVisitorPage(browser: Browser) {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  return { context, page };
+}
+
+test.describe("share folder", () => {
+  test.afterEach(async ({ page }, testInfo) => {
+    const { email } = buildTestUserCredentials(testInfo);
+
+    await clearBrowserStorage(page);
+    await cleanupTestUserByEmail(email);
+  });
+
+  test("navigates inside the shared subtree and blocks escape attempts", async ({
+    browser,
+    page,
+  }, testInfo) => {
+    test.setTimeout(180_000);
+    const credentials = buildTestUserCredentials(testInfo);
+    const visitor = await createVisitorPage(browser);
+
+    try {
+      await signUpAndBypassVerification(page, credentials);
+      await openFilesPage(page);
+      await uploadFiles(page, ["tiny.pdf", "photo.png"]);
+
+      const userId = await getUserIdByEmail(credentials.email);
+      expect(userId).not.toBeNull();
+
+      const rootFolder = await createFolderFixture(userId!, "Shared Root", null);
+      const nestedFolder = await createFolderFixture(userId!, "Nested", rootFolder.id);
+      const outsideFolder = await createFolderFixture(userId!, "Private", null);
+
+      const nestedFileId = await getFileIdForUser(userId!, "tiny.pdf");
+      const outsideFileId = await getFileIdForUser(userId!, "photo.png");
+      expect(nestedFileId).not.toBeNull();
+      expect(outsideFileId).not.toBeNull();
+
+      await moveFileFixture(userId!, nestedFileId!, nestedFolder.id);
+      await moveFileFixture(userId!, outsideFileId!, outsideFolder.id);
+
+      const link = await createShareLinkFixture({
+        allowedEmails: [],
+        createdBy: userId!,
+        expiresAt: null,
+        folderId: rootFolder.id,
+        maxDownloads: null,
+      });
+
+      await visitor.page.goto(`/s/${link.token}`);
+      await expect(visitor.page.getByTestId(`shared-folder-row-${nestedFolder.id}`)).toBeVisible();
+
+      await visitor.page.getByTestId(`shared-folder-row-${nestedFolder.id}`).click();
+      await expect(visitor.page.getByTestId(`shared-breadcrumb-${rootFolder.id}`)).toBeVisible();
+      await expect(visitor.page.getByTestId(`shared-breadcrumb-${nestedFolder.id}`)).toBeVisible();
+      await expect(visitor.page.getByTestId(`shared-file-row-${nestedFileId}`)).toBeVisible();
+
+      await visitor.page.getByTestId(`shared-file-row-${nestedFileId}`).click();
+      await expect(visitor.page.getByTestId("shared-file-view")).toBeVisible();
+      await visitor.page.getByRole("button", { name: "Back to directory" }).click();
+      await expect(visitor.page.getByTestId(`shared-file-row-${nestedFileId}`)).toBeVisible();
+
+      const outsideFolderResponse = await visitor.page.request.get(
+        `/api/share/${link.token}/folder?folderId=${outsideFolder.id}`,
+      );
+      expect(outsideFolderResponse.status()).toBe(404);
+
+      const outsideFileResponse = await visitor.page.request.get(
+        `/api/share/${link.token}/download?fileId=${outsideFileId}`,
+      );
+      expect(outsideFileResponse.status()).toBe(404);
+    } finally {
+      await clearBrowserStorage(visitor.page);
+      await visitor.context.close();
+    }
+  });
+});

--- a/secure-vault/tests/e2e/share-owner-management.spec.ts
+++ b/secure-vault/tests/e2e/share-owner-management.spec.ts
@@ -1,0 +1,98 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { buildTestUserCredentials } from "./helpers/test-user";
+import { cleanupTestUserByEmail } from "./helpers/test-user-cleanup";
+import {
+  clearBrowserStorage,
+  getAllowedEmailsForLink,
+  getFileIdForUser,
+  getLatestShareLinkForTarget,
+  getUserIdByEmail,
+  openFilesPage,
+  signUpAndBypassVerification,
+  uploadFiles,
+} from "./helpers/share";
+
+function getFileActions(page: Page, fileName: string) {
+  return page.locator(`[data-testid^="file-actions-"][data-test-file-name="${fileName}"]`).first();
+}
+
+test.describe("share owner management", () => {
+  test.afterEach(async ({ page }, testInfo) => {
+    const { email } = buildTestUserCredentials(testInfo);
+
+    await clearBrowserStorage(page);
+    await cleanupTestUserByEmail(email);
+  });
+
+  test("creates, edits, and revokes a share link from the owner dialog", async ({
+    page,
+  }, testInfo) => {
+    test.setTimeout(180_000);
+    const credentials = buildTestUserCredentials(testInfo);
+
+    await signUpAndBypassVerification(page, credentials);
+    await openFilesPage(page);
+    await uploadFiles(page, ["tiny.pdf"]);
+
+    const userId = await getUserIdByEmail(credentials.email);
+    expect(userId).not.toBeNull();
+    const fileId = await getFileIdForUser(userId!, "tiny.pdf");
+    expect(fileId).not.toBeNull();
+
+    await getFileActions(page, "tiny.pdf").click();
+    await page.getByRole("menuitem", { name: "Share" }).click();
+
+    const shareDialog = page.getByTestId("share-dialog");
+    await expect(shareDialog).toBeVisible();
+
+    await shareDialog.getByRole("button", { name: "Generate Link" }).click();
+
+    await expect
+      .poll(async () =>
+        getLatestShareLinkForTarget({
+          fileId: fileId!,
+          ownerId: userId!,
+        }),
+      )
+      .not.toBeNull();
+    const link = await getLatestShareLinkForTarget({
+      fileId: fileId!,
+      ownerId: userId!,
+    });
+    expect(link).not.toBeNull();
+
+    const shareRow = page.getByTestId(`share-link-row-${link!.id}`);
+    await expect(shareRow).toBeVisible();
+    await expect(shareRow).toContainText("Public");
+    await expect(shareRow).toContainText("Downloads used: 0 (unlimited)");
+    await expect(shareRow).toContainText("Allowed emails: Public link");
+
+    await shareRow.getByTestId(`share-link-edit-${link!.id}`).click();
+    await page.locator(`#emails-${link!.id}`).fill(
+      " Reader@Example.com, second@example.com, reader@example.com ",
+    );
+    await page.locator(`#downloads-${link!.id}`).fill("3");
+    await shareRow.getByTestId(`share-link-save-${link!.id}`).click();
+
+    await expect(shareRow).toContainText("Restricted");
+    await expect(shareRow).toContainText(
+      "Allowed emails: reader@example.com, second@example.com",
+    );
+    await expect(shareRow).toContainText("Downloads used: 0 of 3");
+    await expect.poll(() => getAllowedEmailsForLink(link!.id)).toEqual([
+      "reader@example.com",
+      "second@example.com",
+    ]);
+
+    await shareRow.getByTestId(`share-link-edit-${link!.id}`).click();
+    await page.locator(`#emails-${link!.id}`).fill("");
+    await shareRow.getByTestId(`share-link-save-${link!.id}`).click();
+
+    await expect(shareRow).toContainText("Public");
+    await expect(shareRow).toContainText("Allowed emails: Public link");
+
+    await shareRow.getByTestId(`share-link-revoke-${link!.id}`).click();
+    await expect(shareRow).toHaveCount(0);
+  });
+});

--- a/secure-vault/tests/e2e/share-owner-validation.spec.ts
+++ b/secure-vault/tests/e2e/share-owner-validation.spec.ts
@@ -1,0 +1,177 @@
+import { expect, test, type Browser, type Page } from "@playwright/test";
+
+import { buildTestUserCredentials } from "./helpers/test-user";
+import { cleanupTestUserByEmail } from "./helpers/test-user-cleanup";
+import {
+  clearBrowserStorage,
+  createShareLinkFixture,
+  getAllowedEmailsForLink,
+  getFileIdForUser,
+  getUserIdByEmail,
+  openFilesPage,
+  signUpAndBypassVerification,
+  uploadFiles,
+} from "./helpers/share";
+
+function getFileActions(page: Page, fileName: string) {
+  return page.locator(`[data-testid^="file-actions-"][data-test-file-name="${fileName}"]`).first();
+}
+
+async function openShareDialogForFile(page: Page, fileName: string) {
+  await getFileActions(page, fileName).click();
+  await page.getByRole("menuitem", { name: "Share" }).click();
+  const shareDialog = page.getByTestId("share-dialog");
+  await expect(shareDialog).toBeVisible();
+  return shareDialog;
+}
+
+async function createVisitorPage(browser: Browser) {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  return { context, page };
+}
+
+test.describe("share owner validation", () => {
+  test.afterEach(async ({ page }, testInfo) => {
+    const { email } = buildTestUserCredentials(testInfo);
+
+    await clearBrowserStorage(page);
+    await cleanupTestUserByEmail(email);
+  });
+
+  test("rejects lowering max downloads below the current usage", async ({
+    browser,
+    page,
+  }, testInfo) => {
+    test.setTimeout(180_000);
+    const credentials = buildTestUserCredentials(testInfo);
+    const visitor = await createVisitorPage(browser);
+
+    try {
+      await signUpAndBypassVerification(page, credentials);
+      await openFilesPage(page);
+      await uploadFiles(page, ["tiny.pdf"]);
+
+      const userId = await getUserIdByEmail(credentials.email);
+      expect(userId).not.toBeNull();
+      const fileId = await getFileIdForUser(userId!, "tiny.pdf");
+      expect(fileId).not.toBeNull();
+
+      const link = await createShareLinkFixture({
+        allowedEmails: [],
+        createdBy: userId!,
+        expiresAt: null,
+        fileId: fileId!,
+        maxDownloads: 2,
+      });
+
+      expect((await visitor.page.request.get(`/api/share/${link.token}/download`)).status()).toBe(200);
+      expect((await visitor.page.request.get(`/api/share/${link.token}/download`)).status()).toBe(200);
+
+      await openShareDialogForFile(page, "tiny.pdf");
+      const shareRow = page.getByTestId(`share-link-row-${link.id}`);
+      await expect(shareRow).toContainText("Download limit reached: 2 used of 2");
+
+      await shareRow.getByTestId(`share-link-edit-${link.id}`).click();
+      await page.locator(`#downloads-${link.id}`).fill("1");
+      await shareRow.getByTestId(`share-link-save-${link.id}`).click();
+
+      await expect(page.getByTestId(`share-link-error-${link.id}`)).toContainText(
+        "Max downloads cannot be lower than the current download count",
+      );
+      await expect(shareRow).toContainText("Download limit reached: 2 used of 2");
+      await expect(page.locator(`#downloads-${link.id}`)).toHaveValue("1");
+    } finally {
+      await clearBrowserStorage(visitor.page);
+      await visitor.context.close();
+    }
+  });
+
+  test("normalizes duplicate mixed-case emails in the owner edit flow", async ({
+    page,
+  }, testInfo) => {
+    test.setTimeout(180_000);
+    const credentials = buildTestUserCredentials(testInfo);
+
+    await signUpAndBypassVerification(page, credentials);
+    await openFilesPage(page);
+    await uploadFiles(page, ["tiny.pdf"]);
+
+    const userId = await getUserIdByEmail(credentials.email);
+    expect(userId).not.toBeNull();
+    const fileId = await getFileIdForUser(userId!, "tiny.pdf");
+    expect(fileId).not.toBeNull();
+
+    const link = await createShareLinkFixture({
+      allowedEmails: [],
+      createdBy: userId!,
+      expiresAt: null,
+      fileId: fileId!,
+      maxDownloads: null,
+    });
+
+    await openShareDialogForFile(page, "tiny.pdf");
+    const shareRow = page.getByTestId(`share-link-row-${link.id}`);
+    await shareRow.getByTestId(`share-link-edit-${link.id}`).click();
+    await page
+      .locator(`#emails-${link.id}`)
+      .fill(" Reader@Example.com, second@example.com, reader@example.com ");
+    await shareRow.getByTestId(`share-link-save-${link.id}`).click();
+
+    await expect(shareRow).toContainText("Restricted");
+    await expect(shareRow).toContainText(
+      "Allowed emails: reader@example.com, second@example.com",
+    );
+    await expect.poll(() => getAllowedEmailsForLink(link.id)).toEqual([
+      "reader@example.com",
+      "second@example.com",
+    ]);
+  });
+
+  test("switches an existing restricted link back to public access", async ({
+    browser,
+    page,
+  }, testInfo) => {
+    test.setTimeout(180_000);
+    const credentials = buildTestUserCredentials(testInfo);
+    const visitor = await createVisitorPage(browser);
+
+    try {
+      await signUpAndBypassVerification(page, credentials);
+      await openFilesPage(page);
+      await uploadFiles(page, ["tiny.pdf"]);
+
+      const userId = await getUserIdByEmail(credentials.email);
+      expect(userId).not.toBeNull();
+      const fileId = await getFileIdForUser(userId!, "tiny.pdf");
+      expect(fileId).not.toBeNull();
+
+      const link = await createShareLinkFixture({
+        allowedEmails: ["reader@example.com"],
+        createdBy: userId!,
+        expiresAt: null,
+        fileId: fileId!,
+        maxDownloads: null,
+      });
+
+      await openShareDialogForFile(page, "tiny.pdf");
+      const shareRow = page.getByTestId(`share-link-row-${link.id}`);
+      await expect(shareRow).toContainText("Restricted");
+
+      await shareRow.getByTestId(`share-link-edit-${link.id}`).click();
+      await page.locator(`#emails-${link.id}`).fill("");
+      await shareRow.getByTestId(`share-link-save-${link.id}`).click();
+
+      await expect(shareRow).toContainText("Public");
+      await expect(shareRow).toContainText("Allowed emails: Public link");
+
+      await visitor.page.goto(`/s/${link.token}`);
+      await expect(visitor.page.getByLabel("Email Address")).toHaveCount(0);
+      await expect(visitor.page.getByRole("button", { name: "Download" })).toBeVisible();
+    } finally {
+      await clearBrowserStorage(visitor.page);
+      await visitor.context.close();
+    }
+  });
+});

--- a/secure-vault/tests/e2e/share-preview-variants.spec.ts
+++ b/secure-vault/tests/e2e/share-preview-variants.spec.ts
@@ -1,0 +1,156 @@
+import { expect, test, type Browser } from "@playwright/test";
+
+import { buildTestUserCredentials } from "./helpers/test-user";
+import { cleanupTestUserByEmail } from "./helpers/test-user-cleanup";
+import {
+  clearBrowserStorage,
+  createFolderFixture,
+  createShareLinkFixture,
+  getFileIdForUser,
+  getUserIdByEmail,
+  openFilesPage,
+  moveFileFixture,
+  signUpAndBypassVerification,
+  uploadFiles,
+} from "./helpers/share";
+
+async function createVisitorPage(browser: Browser) {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  return { context, page };
+}
+
+test.describe("share preview variants", () => {
+  test.afterEach(async ({ page }, testInfo) => {
+    const { email } = buildTestUserCredentials(testInfo);
+
+    await clearBrowserStorage(page);
+    await cleanupTestUserByEmail(email);
+  });
+
+  test("renders the direct public image share with the image preview path", async ({
+    browser,
+    page,
+  }, testInfo) => {
+    test.setTimeout(180_000);
+    const credentials = buildTestUserCredentials(testInfo);
+    const visitor = await createVisitorPage(browser);
+
+    try {
+      await signUpAndBypassVerification(page, credentials);
+      await openFilesPage(page);
+      await uploadFiles(page, ["photo.png"]);
+
+      const userId = await getUserIdByEmail(credentials.email);
+      expect(userId).not.toBeNull();
+      const fileId = await getFileIdForUser(userId!, "photo.png");
+      expect(fileId).not.toBeNull();
+
+      const link = await createShareLinkFixture({
+        allowedEmails: [],
+        createdBy: userId!,
+        expiresAt: null,
+        fileId: fileId!,
+        maxDownloads: null,
+      });
+
+      await visitor.page.goto(`/s/${link.token}`);
+      await expect(visitor.page.getByTestId("shared-preview-image")).toBeVisible();
+      await expect(visitor.page.getByTestId("shared-preview-frame")).toHaveCount(0);
+      await expect(visitor.page.getByLabel("Email Address")).toHaveCount(0);
+    } finally {
+      await clearBrowserStorage(visitor.page);
+      await visitor.context.close();
+    }
+  });
+
+  test("renders the direct public pdf share with the iframe preview path", async ({
+    browser,
+    page,
+  }, testInfo) => {
+    test.setTimeout(180_000);
+    const credentials = buildTestUserCredentials(testInfo);
+    const visitor = await createVisitorPage(browser);
+
+    try {
+      await signUpAndBypassVerification(page, credentials);
+      await openFilesPage(page);
+      await uploadFiles(page, ["tiny.pdf"]);
+
+      const userId = await getUserIdByEmail(credentials.email);
+      expect(userId).not.toBeNull();
+      const fileId = await getFileIdForUser(userId!, "tiny.pdf");
+      expect(fileId).not.toBeNull();
+
+      const link = await createShareLinkFixture({
+        allowedEmails: [],
+        createdBy: userId!,
+        expiresAt: null,
+        fileId: fileId!,
+        maxDownloads: null,
+      });
+
+      await visitor.page.goto(`/s/${link.token}`);
+      await expect(visitor.page.getByTestId("shared-preview-frame")).toBeVisible();
+      await expect(visitor.page.getByTestId("shared-preview-image")).toHaveCount(0);
+      await expect(visitor.page.getByLabel("Email Address")).toHaveCount(0);
+    } finally {
+      await clearBrowserStorage(visitor.page);
+      await visitor.context.close();
+    }
+  });
+
+  test("supports breadcrumb navigation back to the shared root", async ({
+    browser,
+    page,
+  }, testInfo) => {
+    test.setTimeout(180_000);
+    const credentials = buildTestUserCredentials(testInfo);
+    const visitor = await createVisitorPage(browser);
+
+    try {
+      await signUpAndBypassVerification(page, credentials);
+      await openFilesPage(page);
+      await uploadFiles(page, ["tiny.pdf"]);
+
+      const userId = await getUserIdByEmail(credentials.email);
+      expect(userId).not.toBeNull();
+
+      const rootFolder = await createFolderFixture(userId!, "Shared Root", null);
+      const childFolder = await createFolderFixture(userId!, "Child", rootFolder.id);
+      const grandchildFolder = await createFolderFixture(userId!, "Grandchild", childFolder.id);
+
+      const fileId = await getFileIdForUser(userId!, "tiny.pdf");
+      expect(fileId).not.toBeNull();
+      await moveFileFixture(userId!, fileId!, grandchildFolder.id);
+
+      const link = await createShareLinkFixture({
+        allowedEmails: [],
+        createdBy: userId!,
+        expiresAt: null,
+        folderId: rootFolder.id,
+        maxDownloads: null,
+      });
+
+      await visitor.page.goto(`/s/${link.token}`);
+      await expect(visitor.page.getByTestId(`shared-folder-row-${childFolder.id}`)).toBeVisible();
+
+      await visitor.page.getByTestId(`shared-folder-row-${childFolder.id}`).click();
+      await expect(visitor.page.getByTestId(`shared-folder-row-${grandchildFolder.id}`)).toBeVisible();
+      await expect(visitor.page.getByTestId(`shared-breadcrumb-${childFolder.id}`)).toBeVisible();
+
+      await visitor.page.getByTestId(`shared-folder-row-${grandchildFolder.id}`).click();
+      await expect(visitor.page.getByTestId(`shared-file-row-${fileId}`)).toBeVisible();
+      await expect(visitor.page.getByTestId(`shared-breadcrumb-${grandchildFolder.id}`)).toBeVisible();
+
+      await visitor.page.getByTestId(`shared-breadcrumb-${rootFolder.id}`).click();
+      await expect(visitor.page.getByTestId(`shared-folder-row-${childFolder.id}`)).toBeVisible();
+      await expect(visitor.page.getByTestId(`shared-folder-row-${grandchildFolder.id}`)).toHaveCount(0);
+      await expect(visitor.page.getByTestId(`shared-file-row-${fileId}`)).toHaveCount(0);
+    } finally {
+      await clearBrowserStorage(visitor.page);
+      await visitor.context.close();
+    }
+  });
+});

--- a/secure-vault/tests/e2e/share-public-file.spec.ts
+++ b/secure-vault/tests/e2e/share-public-file.spec.ts
@@ -1,0 +1,133 @@
+import { expect, test, type Browser } from "@playwright/test";
+
+import { buildTestUserCredentials } from "./helpers/test-user";
+import { cleanupTestUserByEmail } from "./helpers/test-user-cleanup";
+import {
+  clearBrowserStorage,
+  createShareLinkFixture,
+  expireShareLinkFixture,
+  getFileIdForUser,
+  getShareLinkUsage,
+  getUserIdByEmail,
+  openFilesPage,
+  revokeShareLinkFixture,
+  signUpAndBypassVerification,
+  uploadFiles,
+} from "./helpers/share";
+
+async function createVisitorPage(browser: Browser) {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  return { context, page };
+}
+
+test.describe("share public file", () => {
+  test.afterEach(async ({ page }, testInfo) => {
+    const { email } = buildTestUserCredentials(testInfo);
+
+    await clearBrowserStorage(page);
+    await cleanupTestUserByEmail(email);
+  });
+
+  test("renders a public shared image and serves a real download", async ({ browser, page }, testInfo) => {
+    test.setTimeout(180_000);
+    const credentials = buildTestUserCredentials(testInfo);
+    const visitor = await createVisitorPage(browser);
+
+    try {
+      await signUpAndBypassVerification(page, credentials);
+      await openFilesPage(page);
+      await uploadFiles(page, ["photo.png"]);
+
+      const userId = await getUserIdByEmail(credentials.email);
+      expect(userId).not.toBeNull();
+      const fileId = await getFileIdForUser(userId!, "photo.png");
+      expect(fileId).not.toBeNull();
+
+      const link = await createShareLinkFixture({
+        allowedEmails: [],
+        createdBy: userId!,
+        expiresAt: null,
+        fileId: fileId!,
+        maxDownloads: null,
+      });
+
+      await visitor.page.goto(`/s/${link.token}`);
+      await expect(visitor.page.getByTestId("shared-file-view")).toBeVisible();
+      await expect(visitor.page.getByRole("button", { name: "Download" })).toBeVisible();
+      await expect(visitor.page.getByTestId("shared-preview-image")).toBeVisible();
+      await expect(visitor.page.getByLabel("Email Address")).toHaveCount(0);
+
+      const downloadResult = await visitor.page.evaluate(async (href) => {
+        const response = await fetch(href, { credentials: "same-origin" });
+        const buffer = await response.arrayBuffer();
+
+        return {
+          byteLength: buffer.byteLength,
+          ok: response.ok,
+          status: response.status,
+        };
+      }, `/api/share/${link.token}/download`);
+
+      expect(downloadResult.ok).toBe(true);
+      expect(downloadResult.status).toBe(200);
+      expect(downloadResult.byteLength).toBeGreaterThan(0);
+
+      await expect.poll(async () => (await getShareLinkUsage(link.id))?.downloadCount ?? 0).toBe(1);
+    } finally {
+      await clearBrowserStorage(visitor.page);
+      await visitor.context.close();
+    }
+  });
+
+  test("returns 404 for revoked links and shows expired state for expired links", async ({
+    browser,
+    page,
+  }, testInfo) => {
+    test.setTimeout(180_000);
+    const credentials = buildTestUserCredentials(testInfo);
+    const revokedVisitor = await createVisitorPage(browser);
+    const expiredVisitor = await createVisitorPage(browser);
+
+    try {
+      await signUpAndBypassVerification(page, credentials);
+      await openFilesPage(page);
+      await uploadFiles(page, ["tiny.pdf"]);
+
+      const userId = await getUserIdByEmail(credentials.email);
+      expect(userId).not.toBeNull();
+      const fileId = await getFileIdForUser(userId!, "tiny.pdf");
+      expect(fileId).not.toBeNull();
+
+      const revokedLink = await createShareLinkFixture({
+        allowedEmails: [],
+        createdBy: userId!,
+        expiresAt: null,
+        fileId: fileId!,
+        maxDownloads: null,
+      });
+      await revokeShareLinkFixture(revokedLink.id);
+
+      const revokedResponse = await revokedVisitor.page.goto(`/s/${revokedLink.token}`);
+      expect(revokedResponse?.status()).toBe(404);
+
+      const expiredLink = await createShareLinkFixture({
+        allowedEmails: [],
+        createdBy: userId!,
+        expiresAt: new Date(Date.now() + 60_000),
+        fileId: fileId!,
+        maxDownloads: null,
+      });
+      await expireShareLinkFixture(expiredLink.id);
+
+      await expiredVisitor.page.goto(`/s/${expiredLink.token}`);
+      await expect(expiredVisitor.page.getByRole("heading", { name: "Link Expired" })).toBeVisible();
+    } finally {
+      await clearBrowserStorage(revokedVisitor.page);
+      await clearBrowserStorage(expiredVisitor.page);
+      await revokedVisitor.context.close();
+      await expiredVisitor.context.close();
+    }
+  });
+});

--- a/secure-vault/tests/e2e/share-restricted-edge-cases.spec.ts
+++ b/secure-vault/tests/e2e/share-restricted-edge-cases.spec.ts
@@ -1,0 +1,187 @@
+import { expect, test, type Browser, type Page } from "@playwright/test";
+
+import { buildTestUserCredentials } from "./helpers/test-user";
+import { cleanupTestUserByEmail } from "./helpers/test-user-cleanup";
+import {
+  clearBrowserStorage,
+  createShareLinkFixture,
+  expireLatestShareOtp,
+  getFileIdForUser,
+  getLatestShareOtpRow,
+  getUserIdByEmail,
+  openFilesPage,
+  seedKnownShareOtp,
+  signUpAndBypassVerification,
+  uploadFiles,
+  waitForShareOtpRow,
+} from "./helpers/share";
+
+async function createVisitorPage(browser: Browser) {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  return { context, page };
+}
+
+async function requestOtp(page: Page, email: string) {
+  await page.getByLabel("Email Address").fill(email);
+  await page.getByRole("button", { name: "Send Verification Code" }).click();
+  await expect(page.getByLabel("Verification Code")).toBeVisible();
+}
+
+test.describe("share restricted edge cases", () => {
+  test.afterEach(async ({ page }, testInfo) => {
+    const { email } = buildTestUserCredentials(testInfo);
+
+    await clearBrowserStorage(page);
+    await cleanupTestUserByEmail(email);
+  });
+
+  test("locks the current otp after repeated wrong codes", async ({ browser, page }, testInfo) => {
+    test.setTimeout(180_000);
+    const allowedEmail = "reader@example.com";
+    const visitor = await createVisitorPage(browser);
+
+    try {
+      await signUpAndBypassVerification(page, buildTestUserCredentials(testInfo));
+      await openFilesPage(page);
+      await uploadFiles(page, ["tiny.pdf"]);
+
+      const userId = await getUserIdByEmail(buildTestUserCredentials(testInfo).email);
+      expect(userId).not.toBeNull();
+      const fileId = await getFileIdForUser(userId!, "tiny.pdf");
+      expect(fileId).not.toBeNull();
+
+      const link = await createShareLinkFixture({
+        allowedEmails: [allowedEmail],
+        createdBy: userId!,
+        expiresAt: null,
+        fileId: fileId!,
+        maxDownloads: null,
+      });
+
+      await visitor.page.goto(`/s/${link.token}`);
+      await requestOtp(visitor.page, allowedEmail);
+      await waitForShareOtpRow({ email: allowedEmail, linkId: link.id });
+      await seedKnownShareOtp({ code: "123456", email: allowedEmail, linkId: link.id });
+
+      for (let attempt = 1; attempt <= 2; attempt += 1) {
+        await visitor.page.getByLabel("Verification Code").fill("000000");
+        await visitor.page.getByRole("button", { name: "Verify and Access" }).click();
+        await expect(visitor.page.getByTestId("share-auth-error")).toContainText(
+          "Invalid verification code",
+        );
+      }
+
+      await visitor.page.getByLabel("Verification Code").fill("000000");
+      await visitor.page.getByRole("button", { name: "Verify and Access" }).click();
+      await expect(visitor.page.getByTestId("share-auth-error")).toContainText(
+        "Too many attempts. Please request a new verification code",
+      );
+      await expect(visitor.page.getByLabel("Verification Code")).toBeVisible();
+      await expect(visitor.page.getByRole("button", { name: "Sign out" })).toHaveCount(0);
+    } finally {
+      await clearBrowserStorage(visitor.page);
+      await visitor.context.close();
+    }
+  });
+
+  test("rejects an expired otp and keeps the visitor gated", async ({ browser, page }, testInfo) => {
+    test.setTimeout(180_000);
+    const credentials = buildTestUserCredentials(testInfo);
+    const visitor = await createVisitorPage(browser);
+    const allowedEmail = "reader@example.com";
+
+    try {
+      await signUpAndBypassVerification(page, credentials);
+      await openFilesPage(page);
+      await uploadFiles(page, ["tiny.pdf"]);
+
+      const userId = await getUserIdByEmail(credentials.email);
+      expect(userId).not.toBeNull();
+      const fileId = await getFileIdForUser(userId!, "tiny.pdf");
+      expect(fileId).not.toBeNull();
+
+      const link = await createShareLinkFixture({
+        allowedEmails: [allowedEmail],
+        createdBy: userId!,
+        expiresAt: null,
+        fileId: fileId!,
+        maxDownloads: null,
+      });
+
+      await visitor.page.goto(`/s/${link.token}`);
+      await requestOtp(visitor.page, allowedEmail);
+      await waitForShareOtpRow({ email: allowedEmail, linkId: link.id });
+      await seedKnownShareOtp({ code: "123456", email: allowedEmail, linkId: link.id });
+      await expireLatestShareOtp({ email: allowedEmail, linkId: link.id });
+
+      await visitor.page.getByLabel("Verification Code").fill("123456");
+      await visitor.page.getByRole("button", { name: "Verify and Access" }).click();
+      await expect(visitor.page.getByTestId("share-auth-error")).toContainText(
+        "Verification code has expired",
+      );
+      await expect(visitor.page.getByLabel("Verification Code")).toBeVisible();
+      await expect(visitor.page.getByRole("button", { name: "Sign out" })).toHaveCount(0);
+    } finally {
+      await clearBrowserStorage(visitor.page);
+      await visitor.context.close();
+    }
+  });
+
+  test("invalidates the previous otp when a new code is requested", async ({ browser, page }, testInfo) => {
+    test.setTimeout(180_000);
+    const credentials = buildTestUserCredentials(testInfo);
+    const visitor = await createVisitorPage(browser);
+    const allowedEmail = "reader@example.com";
+
+    try {
+      await signUpAndBypassVerification(page, credentials);
+      await openFilesPage(page);
+      await uploadFiles(page, ["tiny.pdf"]);
+
+      const userId = await getUserIdByEmail(credentials.email);
+      expect(userId).not.toBeNull();
+      const fileId = await getFileIdForUser(userId!, "tiny.pdf");
+      expect(fileId).not.toBeNull();
+
+      const link = await createShareLinkFixture({
+        allowedEmails: [allowedEmail],
+        createdBy: userId!,
+        expiresAt: null,
+        fileId: fileId!,
+        maxDownloads: null,
+      });
+
+      await visitor.page.goto(`/s/${link.token}`);
+      await requestOtp(visitor.page, allowedEmail);
+      await waitForShareOtpRow({ email: allowedEmail, linkId: link.id });
+      await seedKnownShareOtp({ code: "111111", email: allowedEmail, linkId: link.id });
+      const firstOtp = await getLatestShareOtpRow(link.id, allowedEmail);
+      expect(firstOtp).not.toBeNull();
+
+      await visitor.page.getByRole("button", { name: "Use a different email" }).click();
+      await expect(visitor.page.getByLabel("Email Address")).toBeVisible();
+      await requestOtp(visitor.page, allowedEmail);
+      await waitForShareOtpRow({ email: allowedEmail, linkId: link.id });
+      await seedKnownShareOtp({ code: "222222", email: allowedEmail, linkId: link.id });
+      const secondOtp = await getLatestShareOtpRow(link.id, allowedEmail);
+      expect(secondOtp).not.toBeNull();
+      expect(secondOtp?.id).not.toBe(firstOtp?.id);
+
+      await visitor.page.getByLabel("Verification Code").fill("111111");
+      await visitor.page.getByRole("button", { name: "Verify and Access" }).click();
+      await expect(visitor.page.getByTestId("share-auth-error")).toContainText(
+        "Invalid verification code",
+      );
+
+      await visitor.page.getByLabel("Verification Code").fill("222222");
+      await visitor.page.getByRole("button", { name: "Verify and Access" }).click();
+      await expect(visitor.page.getByRole("button", { name: "Sign out" })).toBeVisible();
+      await expect(visitor.page.getByText(`Verified as ${allowedEmail}`)).toBeVisible();
+    } finally {
+      await clearBrowserStorage(visitor.page);
+      await visitor.context.close();
+    }
+  });
+});

--- a/secure-vault/tests/e2e/share-restricted-file.spec.ts
+++ b/secure-vault/tests/e2e/share-restricted-file.spec.ts
@@ -1,0 +1,160 @@
+import { expect, test, type Browser, type Page } from "@playwright/test";
+
+import { buildTestUserCredentials } from "./helpers/test-user";
+import { cleanupTestUserByEmail } from "./helpers/test-user-cleanup";
+import {
+  clearBrowserStorage,
+  createShareLinkFixture,
+  getFileIdForUser,
+  getLatestShareOtpRow,
+  getUserIdByEmail,
+  openFilesPage,
+  seedKnownShareOtp,
+  signUpAndBypassVerification,
+  uploadFiles,
+  waitForShareOtpRow,
+} from "./helpers/share";
+
+async function createVisitorPage(browser: Browser) {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  return { context, page };
+}
+
+async function requestOtp(page: Page, email: string) {
+  await page.getByLabel("Email Address").fill(email);
+  await page.getByRole("button", { name: "Send Verification Code" }).click();
+  await expect(page.getByLabel("Verification Code")).toBeVisible();
+}
+
+test.describe("share restricted file", () => {
+  test.afterEach(async ({ page }, testInfo) => {
+    const { email } = buildTestUserCredentials(testInfo);
+
+    await clearBrowserStorage(page);
+    await cleanupTestUserByEmail(email);
+  });
+
+  test("unlocks with multiple allowlisted emails and supports sign out", async ({
+    browser,
+    page,
+  }, testInfo) => {
+    test.setTimeout(180_000);
+    const credentials = buildTestUserCredentials(testInfo);
+    const visitorA = await createVisitorPage(browser);
+    const visitorB = await createVisitorPage(browser);
+    const allowedEmailA = "reader.one@example.com";
+    const allowedEmailB = "reader.two@example.com";
+
+    try {
+      await signUpAndBypassVerification(page, credentials);
+      await openFilesPage(page);
+      await uploadFiles(page, ["tiny.pdf"]);
+
+      const userId = await getUserIdByEmail(credentials.email);
+      expect(userId).not.toBeNull();
+      const fileId = await getFileIdForUser(userId!, "tiny.pdf");
+      expect(fileId).not.toBeNull();
+
+      const link = await createShareLinkFixture({
+        allowedEmails: [allowedEmailA, allowedEmailB],
+        createdBy: userId!,
+        expiresAt: null,
+        fileId: fileId!,
+        maxDownloads: null,
+      });
+
+      await visitorA.page.goto(`/s/${link.token}`);
+      await expect(visitorA.page.getByLabel("Email Address")).toBeVisible();
+      await requestOtp(visitorA.page, allowedEmailA);
+      await waitForShareOtpRow({ email: allowedEmailA, linkId: link.id });
+      await seedKnownShareOtp({
+        code: "123456",
+        email: allowedEmailA,
+        linkId: link.id,
+      });
+      await visitorA.page.getByLabel("Verification Code").fill("123456");
+      await visitorA.page.getByRole("button", { name: "Verify and Access" }).click();
+      await expect(visitorA.page.getByText(`Verified as ${allowedEmailA}`)).toBeVisible();
+      await expect(visitorA.page.getByRole("button", { name: "Sign out" })).toBeVisible();
+      await expect(visitorA.page.getByRole("button", { name: "Download" })).toBeVisible();
+
+      const logoutResponsePromise = visitorA.page.waitForResponse(
+        (response) =>
+          response.url().includes(`/api/share/${link.token}/logout`) &&
+          response.request().method() === "POST",
+      );
+      await visitorA.page.getByRole("button", { name: "Sign out" }).click();
+      const logoutResponse = await logoutResponsePromise;
+      expect(logoutResponse.status()).toBe(200);
+      await visitorA.page.waitForLoadState("domcontentloaded");
+      await expect(visitorA.page.getByLabel("Email Address")).toBeVisible({ timeout: 10_000 });
+      await expect(visitorA.page.getByRole("button", { name: "Verify and Access" })).toHaveCount(0);
+
+      await visitorB.page.goto(`/s/${link.token}`);
+      await requestOtp(visitorB.page, allowedEmailB);
+      await waitForShareOtpRow({ email: allowedEmailB, linkId: link.id });
+      await seedKnownShareOtp({
+        code: "123456",
+        email: allowedEmailB,
+        linkId: link.id,
+      });
+      await visitorB.page.getByLabel("Verification Code").fill("123456");
+      await visitorB.page.getByRole("button", { name: "Verify and Access" }).click();
+      await expect(visitorB.page.getByText(`Verified as ${allowedEmailB}`)).toBeVisible();
+    } finally {
+      await clearBrowserStorage(visitorA.page);
+      await clearBrowserStorage(visitorB.page);
+      await visitorA.context.close();
+      await visitorB.context.close();
+    }
+  });
+
+  test("does not unlock for a disallowed email", async ({ browser, page }, testInfo) => {
+    test.setTimeout(180_000);
+    const credentials = buildTestUserCredentials(testInfo);
+    const visitor = await createVisitorPage(browser);
+    const allowedEmail = "reader@example.com";
+    const disallowedEmail = "outsider@example.com";
+
+    try {
+      await signUpAndBypassVerification(page, credentials);
+      await openFilesPage(page);
+      await uploadFiles(page, ["tiny.pdf"]);
+
+      const userId = await getUserIdByEmail(credentials.email);
+      expect(userId).not.toBeNull();
+      const fileId = await getFileIdForUser(userId!, "tiny.pdf");
+      expect(fileId).not.toBeNull();
+
+      const link = await createShareLinkFixture({
+        allowedEmails: [allowedEmail],
+        createdBy: userId!,
+        expiresAt: null,
+        fileId: fileId!,
+        maxDownloads: null,
+      });
+
+      await visitor.page.goto(`/s/${link.token}`);
+      await requestOtp(visitor.page, disallowedEmail);
+      await expect.poll(() => getLatestShareOtpRow(link.id, disallowedEmail)).toBeNull();
+
+      await visitor.page.getByLabel("Verification Code").fill("123456");
+      const verifyResponsePromise = visitor.page.waitForResponse(
+        (response) =>
+          response.url().includes(`/api/share/${link.token}/verify-otp`) &&
+          response.request().method() === "POST",
+      );
+      await visitor.page.getByRole("button", { name: "Verify and Access" }).click();
+      const verifyResponse = await verifyResponsePromise;
+
+      expect(verifyResponse.status()).toBe(403);
+      await expect(visitor.page.getByLabel("Verification Code")).toBeVisible();
+      await expect(visitor.page.getByRole("button", { name: "Sign out" })).toHaveCount(0);
+    } finally {
+      await clearBrowserStorage(visitor.page);
+      await visitor.context.close();
+    }
+  });
+});

--- a/secure-vault/tests/e2e/share-session-invalidation.spec.ts
+++ b/secure-vault/tests/e2e/share-session-invalidation.spec.ts
@@ -1,0 +1,175 @@
+import { expect, test, type Browser, type Page } from "@playwright/test";
+
+import { buildTestUserCredentials } from "./helpers/test-user";
+import { cleanupTestUserByEmail } from "./helpers/test-user-cleanup";
+import {
+  clearBrowserStorage,
+  createShareLinkFixture,
+  expireShareLinkFixture,
+  getFileIdForUser,
+  getUserIdByEmail,
+  openFilesPage,
+  revokeShareLinkFixture,
+  seedKnownShareOtp,
+  signUpAndBypassVerification,
+  uploadFiles,
+  waitForShareOtpRow,
+} from "./helpers/share";
+
+async function createVisitorPage(browser: Browser) {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  return { context, page };
+}
+
+async function requestOtp(page: Page, email: string) {
+  await page.getByLabel("Email Address").fill(email);
+  await page.getByRole("button", { name: "Send Verification Code" }).click();
+  await expect(page.getByLabel("Verification Code")).toBeVisible();
+}
+
+async function unlockRestrictedLink(page: Page, link: { id: string; token: string }, email: string) {
+  await page.goto(`/s/${link.token}`);
+  await requestOtp(page, email);
+  await waitForShareOtpRow({ email, linkId: link.id });
+  await seedKnownShareOtp({ code: "123456", email, linkId: link.id });
+  await page.getByLabel("Verification Code").fill("123456");
+  await page.getByRole("button", { name: "Verify and Access" }).click();
+  await expect(page.getByRole("button", { name: "Sign out" })).toBeVisible();
+}
+
+async function fetchPathStatus(page: Page, pathName: string) {
+  return page.evaluate(async (targetPath) => {
+    const response = await fetch(targetPath, {
+      credentials: "same-origin",
+    });
+
+    return response.status;
+  }, pathName);
+}
+
+test.describe("share session invalidation", () => {
+  test.afterEach(async ({ page }, testInfo) => {
+    const { email } = buildTestUserCredentials(testInfo);
+
+    await clearBrowserStorage(page);
+    await cleanupTestUserByEmail(email);
+  });
+
+  test("blocks restricted preview and download without a verified session", async ({
+    browser,
+    page,
+  }, testInfo) => {
+    test.setTimeout(180_000);
+    const credentials = buildTestUserCredentials(testInfo);
+    const visitor = await createVisitorPage(browser);
+    const allowedEmail = "reader@example.com";
+
+    try {
+      await signUpAndBypassVerification(page, credentials);
+      await openFilesPage(page);
+      await uploadFiles(page, ["tiny.pdf"]);
+
+      const userId = await getUserIdByEmail(credentials.email);
+      expect(userId).not.toBeNull();
+      const fileId = await getFileIdForUser(userId!, "tiny.pdf");
+      expect(fileId).not.toBeNull();
+
+      const link = await createShareLinkFixture({
+        allowedEmails: [allowedEmail],
+        createdBy: userId!,
+        expiresAt: null,
+        fileId: fileId!,
+        maxDownloads: null,
+      });
+
+      await visitor.page.goto(`/s/${link.token}`);
+      await expect.poll(() => fetchPathStatus(visitor.page, `/api/share/${link.token}/download`)).toBe(403);
+      await expect.poll(() => fetchPathStatus(visitor.page, `/api/share/${link.token}/preview`)).toBe(403);
+    } finally {
+      await clearBrowserStorage(visitor.page);
+      await visitor.context.close();
+    }
+  });
+
+  test("revocation invalidates an already verified restricted session", async ({
+    browser,
+    page,
+  }, testInfo) => {
+    test.setTimeout(180_000);
+    const credentials = buildTestUserCredentials(testInfo);
+    const visitor = await createVisitorPage(browser);
+    const allowedEmail = "reader@example.com";
+
+    try {
+      await signUpAndBypassVerification(page, credentials);
+      await openFilesPage(page);
+      await uploadFiles(page, ["tiny.pdf"]);
+
+      const userId = await getUserIdByEmail(credentials.email);
+      expect(userId).not.toBeNull();
+      const fileId = await getFileIdForUser(userId!, "tiny.pdf");
+      expect(fileId).not.toBeNull();
+
+      const link = await createShareLinkFixture({
+        allowedEmails: [allowedEmail],
+        createdBy: userId!,
+        expiresAt: null,
+        fileId: fileId!,
+        maxDownloads: null,
+      });
+
+      await unlockRestrictedLink(visitor.page, link, allowedEmail);
+      await revokeShareLinkFixture(link.id);
+
+      const shareResponse = await visitor.page.goto(`/s/${link.token}`);
+      expect(shareResponse?.status()).toBe(404);
+      await expect.poll(() => visitor.page.request.get(`/api/share/${link.token}/download`).then((res) => res.status())).toBe(404);
+      await expect.poll(() => visitor.page.request.get(`/api/share/${link.token}/preview`).then((res) => res.status())).toBe(404);
+    } finally {
+      await clearBrowserStorage(visitor.page);
+      await visitor.context.close();
+    }
+  });
+
+  test("expiry invalidates an already verified restricted session", async ({
+    browser,
+    page,
+  }, testInfo) => {
+    test.setTimeout(180_000);
+    const credentials = buildTestUserCredentials(testInfo);
+    const visitor = await createVisitorPage(browser);
+    const allowedEmail = "reader@example.com";
+
+    try {
+      await signUpAndBypassVerification(page, credentials);
+      await openFilesPage(page);
+      await uploadFiles(page, ["tiny.pdf"]);
+
+      const userId = await getUserIdByEmail(credentials.email);
+      expect(userId).not.toBeNull();
+      const fileId = await getFileIdForUser(userId!, "tiny.pdf");
+      expect(fileId).not.toBeNull();
+
+      const link = await createShareLinkFixture({
+        allowedEmails: [allowedEmail],
+        createdBy: userId!,
+        expiresAt: new Date(Date.now() + 60_000),
+        fileId: fileId!,
+        maxDownloads: null,
+      });
+
+      await unlockRestrictedLink(visitor.page, link, allowedEmail);
+      await expireShareLinkFixture(link.id);
+
+      await visitor.page.goto(`/s/${link.token}`);
+      await expect(visitor.page.getByRole("heading", { name: "Link Expired" })).toBeVisible();
+      await expect.poll(() => visitor.page.request.get(`/api/share/${link.token}/download`).then((res) => res.status())).toBe(410);
+      await expect.poll(() => visitor.page.request.get(`/api/share/${link.token}/preview`).then((res) => res.status())).toBe(410);
+    } finally {
+      await clearBrowserStorage(visitor.page);
+      await visitor.context.close();
+    }
+  });
+});

--- a/secure-vault/tests/services/folder-service.test.ts
+++ b/secure-vault/tests/services/folder-service.test.ts
@@ -366,6 +366,46 @@ describe("folder service", () => {
       );
     });
 
+    it("treats a zero-row update as success when the folder already reflects the target parent", async () => {
+      const harness = createDbHarness({
+        selectResults: [
+          [createFolderRow({ id: "folder-a", parentId: null })],
+          [createFolderRow({ id: "folder-b", parentId: null })],
+          [
+            createFolderRow({ id: "folder-a", parentId: null }),
+            createFolderRow({ id: "folder-b", parentId: null }),
+          ],
+          [createFolderRow({ id: "folder-a", parentId: "folder-b" })],
+        ],
+        updateResults: [{ affectedRows: 0 }],
+      });
+      vi.spyOn(MariadbConnection, "getConnection").mockReturnValue(harness.db as never);
+
+      await expect(moveFolder("user-a", "folder-a", "folder-b")).resolves.toEqual(
+        expect.objectContaining({ id: "folder-a", parentId: "folder-b" }),
+      );
+    });
+
+    it("returns the moved folder when the update succeeds but the follow-up read misses", async () => {
+      const harness = createDbHarness({
+        selectResults: [
+          [createFolderRow({ id: "folder-a", name: "Projects", parentId: null })],
+          [createFolderRow({ id: "folder-b", name: "Archive", parentId: null })],
+          [
+            createFolderRow({ id: "folder-a", name: "Projects", parentId: null }),
+            createFolderRow({ id: "folder-b", name: "Archive", parentId: null }),
+          ],
+          [],
+        ],
+        updateResults: [{ affectedRows: 1 }],
+      });
+      vi.spyOn(MariadbConnection, "getConnection").mockReturnValue(harness.db as never);
+
+      await expect(moveFolder("user-a", "folder-a", "folder-b")).resolves.toEqual(
+        expect.objectContaining({ id: "folder-a", name: "Projects", parentId: "folder-b" }),
+      );
+    });
+
     it("rejects direct self-moves", async () => {
       const harness = createDbHarness({
         selectResults: [

--- a/secure-vault/tests/sharing/otp-service.test.ts
+++ b/secure-vault/tests/sharing/otp-service.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MariadbConnection } from "@/lib/db";
+import { OtpServiceError, createAndSendOtp } from "@/lib/sharing/otp-service";
+
+const mocks = vi.hoisted(() => ({
+  assertShareLinkAccessible: vi.fn(),
+  sendOTPEmail: vi.fn(),
+  requireShareLinkByToken: vi.fn(),
+}));
+
+vi.mock("nanoid", () => ({
+  nanoid: () => "otp-1",
+}));
+
+vi.mock("@/lib/email", () => ({
+  sendOTPEmail: mocks.sendOTPEmail,
+}));
+
+vi.mock("@/lib/sharing/share-service", () => ({
+  ShareServiceError: class ShareServiceError extends Error {
+    code: string;
+    status: number;
+
+    constructor(code: string, message: string, status: number) {
+      super(message);
+      this.code = code;
+      this.status = status;
+    }
+  },
+  assertShareLinkAccessible: mocks.assertShareLinkAccessible,
+  requireShareLinkByToken: mocks.requireShareLinkByToken,
+}));
+
+function createDbHarness(selectResults: unknown[][] = []) {
+  const selectQueue = [...selectResults];
+  const selectLimit = vi.fn(async () => selectQueue.shift() ?? []);
+  const selectWhere = vi.fn(() => ({ limit: selectLimit }));
+  const selectFrom = vi.fn(() => ({ where: selectWhere }));
+  const select = vi.fn(() => ({ from: selectFrom }));
+  const insertValues = vi.fn(async () => ({}));
+  const insert = vi.fn(() => ({ values: insertValues }));
+  const updateWhere = vi.fn(async () => ({ affectedRows: 1 }));
+  const updateSet = vi.fn(() => ({ where: updateWhere }));
+  const update = vi.fn(() => ({ set: updateSet }));
+
+  return {
+    db: {
+      insert,
+      select,
+      update,
+    },
+    spies: {
+      insert,
+      insertValues,
+      select,
+      update,
+      updateSet,
+      updateWhere,
+    },
+  };
+}
+
+describe("otp service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(MariadbConnection, "getConnection").mockImplementation(() => {
+      throw new Error("getConnection mock not configured");
+    });
+    mocks.requireShareLinkByToken.mockResolvedValue({
+      allowedEmails: ["reader@example.com"],
+      expires_at: null,
+      id: "link-1",
+      is_public: false,
+      revoked_at: null,
+    });
+  });
+
+  it("cleans up the inserted otp when email delivery fails", async () => {
+    const harness = createDbHarness([[{ email: "reader@example.com" }]]);
+    vi.spyOn(MariadbConnection, "getConnection").mockReturnValue(harness.db as never);
+    mocks.sendOTPEmail.mockRejectedValue(new Error("Email delivery failed: sandbox restriction"));
+
+    await expect(
+      createAndSendOtp({ email: "reader@example.com", token: "share-token" }),
+    ).rejects.toMatchObject({
+      code: "DELIVERY_FAILED",
+      status: 503,
+    });
+
+    expect(harness.spies.insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: "reader@example.com",
+        id: "otp-1",
+        link_id: "link-1",
+      }),
+    );
+    expect(harness.spies.update).toHaveBeenCalledTimes(1);
+    expect(mocks.sendOTPEmail).toHaveBeenCalledWith("reader@example.com", expect.any(String));
+  });
+
+  it("invalidates older otps only after a successful email send", async () => {
+    const harness = createDbHarness([[{ email: "reader@example.com" }]]);
+    vi.spyOn(MariadbConnection, "getConnection").mockReturnValue(harness.db as never);
+    mocks.sendOTPEmail.mockResolvedValue(undefined);
+
+    await expect(
+      createAndSendOtp({ email: "reader@example.com", token: "share-token" }),
+    ).resolves.toBeUndefined();
+
+    expect(harness.spies.update).toHaveBeenCalledTimes(2);
+    expect(mocks.sendOTPEmail).toHaveBeenCalledWith("reader@example.com", expect.any(String));
+  });
+});

--- a/secure-vault/tests/sharing/request-otp-route.test.ts
+++ b/secure-vault/tests/sharing/request-otp-route.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  createAndSendOtp: vi.fn(),
+}));
+
+vi.mock("@/lib/sharing/otp-service", () => ({
+  createAndSendOtp: mocks.createAndSendOtp,
+  isShareOrOtpError: (error: unknown) =>
+    Boolean(
+      error
+      && typeof error === "object"
+      && "status" in (error as Record<string, unknown>)
+      && "message" in (error as Record<string, unknown>),
+    ),
+}));
+
+import { POST } from "@/app/api/share/[token]/request-otp/route";
+
+function createRequest(body: unknown) {
+  return new Request("https://example.com/api/share/token/request-otp", {
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+    method: "POST",
+  });
+}
+
+describe("request otp route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 400 when email is missing", async () => {
+    const response = await POST(createRequest({}) as never, {
+      params: Promise.resolve({ token: "share-token" }),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Email is required" });
+  });
+
+  it("returns generic success when otp is created", async () => {
+    mocks.createAndSendOtp.mockResolvedValue(undefined);
+
+    const response = await POST(createRequest({ email: "reader@example.com" }) as never, {
+      params: Promise.resolve({ token: "share-token" }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      message: "If the email is allowed, a code has been sent.",
+      success: true,
+    });
+    expect(mocks.createAndSendOtp).toHaveBeenCalledWith({
+      email: "reader@example.com",
+      token: "share-token",
+    });
+  });
+
+  it("keeps the response generic for disallowed emails", async () => {
+    mocks.createAndSendOtp.mockRejectedValueOnce({
+      code: "EMAIL_NOT_ALLOWED",
+      message: "If the email is allowed, a code has been sent.",
+      status: 200,
+    });
+
+    const response = await POST(createRequest({ email: "blocked@example.com" }) as never, {
+      params: Promise.resolve({ token: "share-token" }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      message: "If the email is allowed, a code has been sent.",
+      success: true,
+    });
+  });
+
+  it("maps expected service errors to status codes", async () => {
+    mocks.createAndSendOtp.mockRejectedValueOnce({
+      code: "EXPIRED",
+      message: "Share link is expired",
+      status: 410,
+    });
+
+    const response = await POST(createRequest({ email: "reader@example.com" }) as never, {
+      params: Promise.resolve({ token: "share-token" }),
+    });
+
+    expect(response.status).toBe(410);
+    await expect(response.json()).resolves.toEqual({ error: "Share link is expired" });
+  });
+
+  it("surfaces delivery failures without exposing a 500", async () => {
+    mocks.createAndSendOtp.mockRejectedValueOnce({
+      code: "DELIVERY_FAILED",
+      message: "Failed to deliver verification code",
+      status: 503,
+    });
+
+    const response = await POST(createRequest({ email: "reader@example.com" }) as never, {
+      params: Promise.resolve({ token: "share-token" }),
+    });
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({ error: "Failed to deliver verification code" });
+  });
+});

--- a/secure-vault/tests/sharing/share-access-session.test.ts
+++ b/secure-vault/tests/sharing/share-access-session.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AUTH_COOKIE_SECURE } from "@/lib/auth/cookies";
+
+const mocks = vi.hoisted(() => ({
+  cookies: vi.fn(),
+  decrypt: vi.fn(),
+  encrypt: vi.fn(),
+  getMasterKey: vi.fn(),
+  getShareLinkByToken: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: mocks.cookies,
+}));
+
+vi.mock("@/lib/crypto/aes", () => ({
+  decrypt: mocks.decrypt,
+  encrypt: mocks.encrypt,
+}));
+
+vi.mock("@/lib/crypto/keys", () => ({
+  getMasterKey: mocks.getMasterKey,
+}));
+
+vi.mock("@/lib/sharing/share-service", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/sharing/share-service")>(
+    "@/lib/sharing/share-service",
+  );
+
+  return {
+    ...actual,
+    getShareLinkByToken: mocks.getShareLinkByToken,
+  };
+});
+
+import {
+  clearShareAccessSession,
+  createShareAccessSession,
+  readShareAccessSession,
+  requireValidShareAccessSession,
+} from "@/lib/sharing/share-access-session";
+
+describe("share access session", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getMasterKey.mockReturnValue(Buffer.alloc(32, 7));
+  });
+
+  it("writes a root-scoped httpOnly cookie when creating a session", async () => {
+    const set = vi.fn();
+    mocks.encrypt.mockReturnValue(Buffer.from("encrypted"));
+    mocks.cookies.mockResolvedValue({ set });
+
+    await createShareAccessSession({
+      email: "reader@example.com",
+      expiresAt: new Date("2026-05-01T00:00:00.000Z"),
+      linkId: "link-1",
+    });
+
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        httpOnly: true,
+        name: `${AUTH_COOKIE_SECURE ? "__Secure-" : ""}share-link-1`,
+        path: "/",
+        sameSite: "lax",
+        secure: AUTH_COOKIE_SECURE,
+      }),
+    );
+  });
+
+  it("returns null when the stored session is missing", async () => {
+    mocks.cookies.mockResolvedValue({
+      get: vi.fn(() => undefined),
+    });
+
+    await expect(readShareAccessSession("link-1")).resolves.toBeNull();
+  });
+
+  it("returns null when the session link id does not match", async () => {
+    mocks.cookies.mockResolvedValue({
+      get: vi.fn(() => ({ value: Buffer.from("encrypted").toString("hex") })),
+    });
+    mocks.decrypt.mockReturnValue(
+      Buffer.from(
+        JSON.stringify({
+          email: "reader@example.com",
+          expiresAt: "2099-01-01T00:00:00.000Z",
+          linkId: "other-link",
+          verifiedAt: "2026-04-01T00:00:00.000Z",
+        }),
+      ),
+    );
+
+    await expect(readShareAccessSession("link-1")).resolves.toBeNull();
+  });
+
+  it("requires a matching active link when validating a session", async () => {
+    mocks.cookies.mockResolvedValue({
+      get: vi.fn(() => ({ value: Buffer.from("encrypted").toString("hex") })),
+    });
+    mocks.decrypt.mockReturnValue(
+      Buffer.from(
+        JSON.stringify({
+          email: "reader@example.com",
+          expiresAt: "2099-01-01T00:00:00.000Z",
+          linkId: "link-1",
+          verifiedAt: "2026-04-01T00:00:00.000Z",
+        }),
+      ),
+    );
+    mocks.getShareLinkByToken.mockResolvedValue({
+      expires_at: null,
+      id: "link-1",
+      revoked_at: null,
+    });
+
+    await expect(
+      requireValidShareAccessSession({ linkId: "link-1", token: "share-token" }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        email: "reader@example.com",
+        linkId: "link-1",
+      }),
+    );
+  });
+
+  it("clears the cookie at the root path", async () => {
+    const set = vi.fn();
+    mocks.cookies.mockResolvedValue({ set });
+
+    await clearShareAccessSession("link-1");
+
+    expect(set).toHaveBeenCalledWith(
+      `${AUTH_COOKIE_SECURE ? "__Secure-" : ""}share-link-1`,
+      "",
+      expect.objectContaining({
+        httpOnly: true,
+        maxAge: 0,
+        path: "/",
+        sameSite: "lax",
+        secure: AUTH_COOKIE_SECURE,
+      }),
+    );
+  });
+});

--- a/secure-vault/tests/sharing/share-links-route.test.ts
+++ b/secure-vault/tests/sharing/share-links-route.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getCurrentUser: vi.fn(),
+  listShareLinksForOwner: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/get-current-user", () => ({
+  getCurrentUser: mocks.getCurrentUser,
+}));
+
+vi.mock("@/lib/sharing/share-service", () => ({
+  listShareLinksForOwner: mocks.listShareLinksForOwner,
+}));
+
+import { GET } from "@/app/api/share/links/route";
+
+describe("share links route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 for unauthenticated users", async () => {
+    mocks.getCurrentUser.mockResolvedValue(null);
+
+    const response = await GET(new Request("https://example.com/api/share/links?fileId=file-1") as never);
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 400 when neither fileId nor folderId is provided", async () => {
+    mocks.getCurrentUser.mockResolvedValue({ email_verified: true, id: "user-1" });
+
+    const response = await GET(new Request("https://example.com/api/share/links") as never);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Must specify either a fileId or folderId",
+    });
+  });
+
+  it("returns owner-scoped links for a valid request", async () => {
+    mocks.getCurrentUser.mockResolvedValue({ email_verified: true, id: "user-1" });
+    mocks.listShareLinksForOwner.mockResolvedValue([{ id: "link-1" }]);
+
+    const response = await GET(new Request("https://example.com/api/share/links?fileId=file-1") as never);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual([{ id: "link-1" }]);
+    expect(mocks.listShareLinksForOwner).toHaveBeenCalledWith({
+      fileId: "file-1",
+      folderId: undefined,
+      ownerId: "user-1",
+    });
+  });
+});

--- a/secure-vault/tests/sharing/share-logout-route.test.ts
+++ b/secure-vault/tests/sharing/share-logout-route.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  clearShareAccessSession: vi.fn(),
+  requireShareLinkByToken: vi.fn(),
+}));
+
+vi.mock("@/lib/sharing/share-access-session", () => ({
+  clearShareAccessSession: mocks.clearShareAccessSession,
+}));
+
+vi.mock("@/lib/sharing/share-service", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/sharing/share-service")>(
+    "@/lib/sharing/share-service",
+  );
+
+  return {
+    ...actual,
+    requireShareLinkByToken: mocks.requireShareLinkByToken,
+  };
+});
+
+import { POST } from "@/app/api/share/[token]/logout/route";
+import { ShareServiceError } from "@/lib/sharing/share-service";
+
+describe("share logout route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("clears the session for the current share link", async () => {
+    mocks.requireShareLinkByToken.mockResolvedValue({
+      id: "link-1",
+    });
+
+    const response = await POST(new Request("https://example.com") as never, {
+      params: Promise.resolve({ token: "share-token" }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ success: true });
+    expect(mocks.clearShareAccessSession).toHaveBeenCalledWith("link-1");
+  });
+
+  it("maps missing links to the service status code", async () => {
+    mocks.requireShareLinkByToken.mockRejectedValueOnce(
+      new ShareServiceError("NOT_FOUND", "Share link not found", 404),
+    );
+
+    const response = await POST(new Request("https://example.com") as never, {
+      params: Promise.resolve({ token: "missing-token" }),
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "Share link not found" });
+    expect(mocks.clearShareAccessSession).not.toHaveBeenCalled();
+  });
+});

--- a/secure-vault/tests/sharing/share-page.test.tsx
+++ b/secure-vault/tests/sharing/share-page.test.tsx
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  notFound: vi.fn(() => {
+    throw new Error("NOT_FOUND");
+  }),
+  requireSharedFileSummary: vi.fn(),
+  requireShareLinkByToken: vi.fn(),
+  requireValidShareAccessSession: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: mocks.notFound,
+}));
+
+vi.mock("@/lib/sharing/share-access-session", () => ({
+  requireValidShareAccessSession: mocks.requireValidShareAccessSession,
+}));
+
+vi.mock("@/lib/sharing/share-service", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/sharing/share-service")>(
+    "@/lib/sharing/share-service",
+  );
+
+  return {
+    ...actual,
+    requireSharedFileSummary: mocks.requireSharedFileSummary,
+    requireShareLinkByToken: mocks.requireShareLinkByToken,
+  };
+});
+
+import SharedLinkPage from "@/app/s/[token]/page";
+import { ShareServiceError } from "@/lib/sharing/share-service";
+
+describe("shared link page", () => {
+  it("renders the auth view for restricted links without a session", async () => {
+    mocks.requireShareLinkByToken.mockResolvedValue({
+      allowedEmails: ["reader@example.com"],
+      expires_at: null,
+      id: "link-1",
+      is_public: false,
+      revoked_at: null,
+      targetId: "file-1",
+      targetType: "file",
+    });
+    mocks.requireValidShareAccessSession.mockResolvedValue(null);
+
+    const element = await SharedLinkPage({
+      params: Promise.resolve({ token: "share-token" }),
+    });
+
+    expect(element).toMatchObject({
+      props: { token: "share-token" },
+      type: expect.any(Function),
+    });
+  });
+
+  it("passes file metadata to the shared file view for direct file links", async () => {
+    mocks.requireShareLinkByToken.mockResolvedValue({
+      allowedEmails: [],
+      created_by: "owner-1",
+      expires_at: null,
+      id: "link-1",
+      is_public: true,
+      revoked_at: null,
+      targetId: "file-1",
+      targetType: "file",
+    });
+    mocks.requireSharedFileSummary.mockResolvedValue({
+      id: "file-1",
+      mimeType: "image/png",
+      name: "preview.png",
+    });
+
+    const element = await SharedLinkPage({
+      params: Promise.resolve({ token: "share-token" }),
+    });
+
+    expect(element).toMatchObject({
+      props: expect.objectContaining({
+        fileId: "file-1",
+        fileName: "preview.png",
+        mimeType: "image/png",
+        token: "share-token",
+      }),
+      type: expect.any(Function),
+    });
+  });
+
+  it("renders the expired state for expired links", async () => {
+    mocks.requireShareLinkByToken.mockRejectedValueOnce(
+      new ShareServiceError("EXPIRED", "Share link is expired", 410),
+    );
+
+    const element = await SharedLinkPage({
+      params: Promise.resolve({ token: "share-token" }),
+    });
+
+    expect(element).toMatchObject({
+      props: {},
+      type: expect.any(Function),
+    });
+    expect((element.type as Function).name).toBe("ExpiredState");
+  });
+
+  it("uses notFound for revoked or missing links", async () => {
+    mocks.requireShareLinkByToken.mockRejectedValueOnce(
+      new ShareServiceError("NOT_FOUND", "Share link not found", 404),
+    );
+
+    await expect(
+      SharedLinkPage({ params: Promise.resolve({ token: "share-token" }) }),
+    ).rejects.toThrow("NOT_FOUND");
+  });
+});

--- a/secure-vault/tests/sharing/share-routes.test.ts
+++ b/secure-vault/tests/sharing/share-routes.test.ts
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  assertDownloadAllowed: vi.fn(),
+  assertShareLinkAccessible: vi.fn(),
+  recordShareAccess: vi.fn(),
+  requireFolderShareTargetFile: vi.fn(),
+  requireShareLinkByToken: vi.fn(),
+  requireSharedFolderContents: vi.fn(),
+  requireValidShareAccessSession: vi.fn(),
+  streamSharedFile: vi.fn(),
+}));
+
+vi.mock("@/lib/sharing/share-access-session", () => ({
+  requireValidShareAccessSession: mocks.requireValidShareAccessSession,
+}));
+
+vi.mock("@/app/api/files/[id]/service", () => ({
+  FileDownloadServiceError: class FileDownloadServiceError extends Error {
+    status: number;
+
+    constructor(message: string, status: number) {
+      super(message);
+      this.status = status;
+    }
+  },
+  streamSharedFile: mocks.streamSharedFile,
+}));
+
+vi.mock("@/lib/sharing/share-service", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/sharing/share-service")>(
+    "@/lib/sharing/share-service",
+  );
+
+  return {
+    ...actual,
+    assertDownloadAllowed: mocks.assertDownloadAllowed,
+    assertShareLinkAccessible: mocks.assertShareLinkAccessible,
+    recordShareAccess: mocks.recordShareAccess,
+    requireFolderShareTargetFile: mocks.requireFolderShareTargetFile,
+    requireShareLinkByToken: mocks.requireShareLinkByToken,
+    requireSharedFolderContents: mocks.requireSharedFolderContents,
+  };
+});
+
+import { GET as getDownload } from "@/app/api/share/[token]/download/route";
+import { GET as getFolder } from "@/app/api/share/[token]/folder/route";
+import { GET as getPreview } from "@/app/api/share/[token]/preview/route";
+
+function createLink(overrides: Partial<{
+  allowedEmails: string[];
+  created_by: string;
+  id: string;
+  is_public: boolean;
+  targetId: string;
+  targetType: "file" | "folder";
+}> = {}) {
+  return {
+    allowedEmails: [],
+    created_by: "owner-1",
+    id: "link-1",
+    is_public: true,
+    targetId: "file-1",
+    targetType: "file" as const,
+    ...overrides,
+  };
+}
+
+describe("share routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.requireShareLinkByToken.mockResolvedValue(createLink());
+    mocks.streamSharedFile.mockResolvedValue(new Response("shared-bytes", { status: 200 }));
+    mocks.requireSharedFolderContents.mockResolvedValue({
+      breadcrumb: [{ id: "folder-root", name: "Root" }],
+      currentFolder: { id: "folder-root", name: "Root" },
+      files: [],
+      folders: [],
+    });
+  });
+
+  it("downloads a public file share without a verified session", async () => {
+    const response = await getDownload(
+      new Request("https://example.com/api/share/share-token/download") as never,
+      { params: Promise.resolve({ token: "share-token" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.streamSharedFile).toHaveBeenCalledWith({
+      disposition: "attachment",
+      fileId: "file-1",
+      ownerId: "owner-1",
+      signal: expect.any(AbortSignal),
+    });
+    expect(mocks.assertDownloadAllowed).toHaveBeenCalledWith("link-1");
+  });
+
+  it("requires a verified session for restricted downloads", async () => {
+    mocks.requireShareLinkByToken.mockResolvedValue(
+      createLink({
+        allowedEmails: ["reader@example.com"],
+        is_public: false,
+      }),
+    );
+    mocks.requireValidShareAccessSession.mockResolvedValue(null);
+
+    const response = await getDownload(
+      new Request("https://example.com/api/share/share-token/download") as never,
+      { params: Promise.resolve({ token: "share-token" }) },
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "Access denied" });
+  });
+
+  it("resolves folder-share downloads through subtree validation", async () => {
+    mocks.requireShareLinkByToken.mockResolvedValue(
+      createLink({ targetId: "folder-root", targetType: "folder" }),
+    );
+    mocks.requireFolderShareTargetFile.mockResolvedValue("file-in-folder");
+
+    const response = await getDownload(
+      new Request("https://example.com/api/share/share-token/download?fileId=file-in-folder") as never,
+      { params: Promise.resolve({ token: "share-token" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.requireFolderShareTargetFile).toHaveBeenCalledWith({
+      fileId: "file-in-folder",
+      ownerId: "owner-1",
+      rootFolderId: "folder-root",
+    });
+  });
+
+  it("uses inline disposition for previews", async () => {
+    const response = await getPreview(
+      new Request("https://example.com/api/share/share-token/preview") as never,
+      { params: Promise.resolve({ token: "share-token" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.streamSharedFile).toHaveBeenCalledWith({
+      disposition: "inline",
+      fileId: "file-1",
+      ownerId: "owner-1",
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("does not consume a download slot when file streaming fails before a response is ready", async () => {
+    mocks.streamSharedFile.mockRejectedValueOnce(new Error("stream setup failed"));
+
+    const response = await getDownload(
+      new Request("https://example.com/api/share/share-token/download") as never,
+      { params: Promise.resolve({ token: "share-token" }) },
+    );
+
+    expect(response.status).toBe(500);
+    expect(mocks.assertDownloadAllowed).not.toHaveBeenCalled();
+    expect(mocks.recordShareAccess).not.toHaveBeenCalled();
+  });
+
+  it("returns folder contents only for folder shares", async () => {
+    mocks.requireShareLinkByToken.mockResolvedValue(
+      createLink({ targetId: "folder-root", targetType: "folder" }),
+    );
+
+    const response = await getFolder(
+      new Request("https://example.com/api/share/share-token/folder?folderId=folder-root") as never,
+      { params: Promise.resolve({ token: "share-token" }) },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      breadcrumb: [{ id: "folder-root", name: "Root" }],
+      currentFolder: { id: "folder-root", name: "Root" },
+      files: [],
+      folders: [],
+    });
+    expect(mocks.requireSharedFolderContents).toHaveBeenCalledWith({
+      currentFolderId: "folder-root",
+      ownerId: "owner-1",
+      rootFolderId: "folder-root",
+    });
+  });
+});

--- a/secure-vault/tests/sharing/share-service.test.ts
+++ b/secure-vault/tests/sharing/share-service.test.ts
@@ -1,0 +1,244 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MariadbConnection } from "@/lib/db";
+import { files, folders } from "@/lib/db/schema";
+import {
+  assertShareLinkAccessible,
+  requireFolderShareTargetFile,
+  requireSharedFileSummary,
+  ShareServiceError,
+  updateShareLinkSettings,
+} from "@/lib/sharing/share-service";
+
+function createSelectHarness(selects: {
+  fileRows?: Array<{ folderId: string | null; id: string }>;
+  folderRows?: Array<{ id: string; parentId: string | null }>;
+}) {
+  const fileLimit = vi.fn().mockResolvedValue(selects.fileRows ?? []);
+  const fileWhere = vi.fn(() => ({ limit: fileLimit }));
+  const folderThen = vi.fn().mockResolvedValue(selects.folderRows ?? []);
+  const folderWhereResult = {
+    then: (onFulfilled: (value: unknown[]) => unknown, onRejected?: (reason: unknown) => unknown) =>
+      folderThen().then(onFulfilled, onRejected),
+  };
+  const folderWhere = vi.fn(() => folderWhereResult);
+
+  const selectFrom = vi.fn((table: unknown) => {
+    if (table === files) {
+      return { where: fileWhere };
+    }
+
+    if (table === folders) {
+      return { where: folderWhere };
+    }
+
+    throw new Error("Unexpected table");
+  });
+
+  return {
+    db: {
+      select: vi.fn(() => ({ from: selectFrom })),
+    },
+    spies: {
+      fileLimit,
+      fileWhere,
+      folderThen,
+      folderWhere,
+      selectFrom,
+    },
+  };
+}
+
+function createSettingsHarness(options?: {
+  emailRows?: Array<{ email: string }>;
+  initialLinkRows?: Array<{ download_count: number; id: string }>;
+  updatedLinkRows?: Array<{
+    created_by: string;
+    download_count: number;
+    file_id: string | null;
+    folder_id: string | null;
+    id: string;
+    is_public: boolean;
+    max_downloads: number | null;
+    token: string;
+  }>;
+}) {
+  const linkQueue = [
+    ...(options?.initialLinkRows ?? []),
+    ...(options?.updatedLinkRows ?? []),
+  ];
+  const emailQueue = [
+    ...(options?.emailRows ?? []),
+  ];
+
+  const deleteWhere = vi.fn(async () => ({}));
+  const deleteFn = vi.fn(() => ({ where: deleteWhere }));
+  const insertValues = vi.fn(async () => ({}));
+  const insertFn = vi.fn(() => ({ values: insertValues }));
+  const updateWhere = vi.fn(async () => ({ affectedRows: 1 }));
+  const updateSet = vi.fn(() => ({ where: updateWhere }));
+  const updateFn = vi.fn(() => ({ set: updateSet }));
+  const selectLimit = vi.fn(async () => {
+    const next = linkQueue.shift();
+    return next ? [next] : [];
+  });
+  const selectWhere = vi.fn((predicate?: unknown) => {
+    const marker = String(predicate ?? "");
+
+    if (marker.includes("share_link_emails")) {
+      return {
+        then: (onFulfilled: (value: unknown[]) => unknown, onRejected?: (reason: unknown) => unknown) =>
+          Promise.resolve(emailQueue).then(onFulfilled, onRejected),
+      };
+    }
+
+    return { limit: selectLimit };
+  });
+  const selectFrom = vi.fn(() => ({ where: selectWhere }));
+  const selectFn = vi.fn(() => ({ from: selectFrom }));
+
+  const db = {
+    delete: deleteFn,
+    insert: insertFn,
+    select: selectFn,
+    transaction: vi.fn(),
+    update: updateFn,
+  };
+  db.transaction.mockImplementation(async (callback: (tx: typeof db) => unknown) => callback(db));
+
+  return {
+    db,
+    spies: {
+      deleteFn,
+      deleteWhere,
+      insertFn,
+      insertValues,
+      selectFn,
+      selectLimit,
+      selectWhere,
+      transaction: db.transaction,
+      updateFn,
+      updateSet,
+      updateWhere,
+    },
+  };
+}
+
+describe("share service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(MariadbConnection, "getConnection").mockImplementation(() => {
+      throw new Error("getConnection mock not configured");
+    });
+  });
+
+  it("treats revoked links as not found", () => {
+    expect(() =>
+      assertShareLinkAccessible({
+        expires_at: null,
+        revoked_at: new Date(),
+      }),
+    ).toThrowError(new ShareServiceError("NOT_FOUND", "Share link not found", 404));
+  });
+
+  it("treats expired links as expired", () => {
+    expect(() =>
+      assertShareLinkAccessible({
+        expires_at: new Date("2020-01-01T00:00:00.000Z"),
+        revoked_at: null,
+      }),
+    ).toThrowError(new ShareServiceError("EXPIRED", "Share link is expired", 410));
+  });
+
+  it("allows folder-share file access only when the file lives in the shared subtree", async () => {
+    const harness = createSelectHarness({
+      fileRows: [{ folderId: "child-folder", id: "file-1" }],
+      folderRows: [
+        { id: "root-folder", parentId: null },
+        { id: "child-folder", parentId: "root-folder" },
+        { id: "sibling-folder", parentId: null },
+      ],
+    });
+    vi.spyOn(MariadbConnection, "getConnection").mockReturnValue(harness.db as never);
+
+    await expect(
+      requireFolderShareTargetFile({
+        fileId: "file-1",
+        ownerId: "user-1",
+        rootFolderId: "root-folder",
+      }),
+    ).resolves.toBe("file-1");
+  });
+
+  it("rejects folder-share file access outside the shared subtree", async () => {
+    const harness = createSelectHarness({
+      fileRows: [{ folderId: "sibling-folder", id: "file-2" }],
+      folderRows: [
+        { id: "root-folder", parentId: null },
+        { id: "child-folder", parentId: "root-folder" },
+        { id: "sibling-folder", parentId: null },
+      ],
+    });
+    vi.spyOn(MariadbConnection, "getConnection").mockReturnValue(harness.db as never);
+
+    await expect(
+      requireFolderShareTargetFile({
+        fileId: "file-2",
+        ownerId: "user-1",
+        rootFolderId: "root-folder",
+      }),
+    ).rejects.toThrowError(new ShareServiceError("NOT_FOUND", "Share link not found", 404));
+  });
+
+  it("loads direct file metadata for shared file pages", async () => {
+    const fileLimit = vi.fn().mockResolvedValue([
+      { id: "file-1", mimeType: "image/png", name: "preview.png" },
+    ]);
+    const fileWhere = vi.fn(() => ({ limit: fileLimit }));
+    const selectFrom = vi.fn((table: unknown) => {
+      if (table === files) {
+        return { where: fileWhere };
+      }
+
+      throw new Error("Unexpected table");
+    });
+    const db = {
+      select: vi.fn(() => ({ from: selectFrom })),
+    };
+    vi.spyOn(MariadbConnection, "getConnection").mockReturnValue(db as never);
+
+    await expect(
+      requireSharedFileSummary({
+        fileId: "file-1",
+        ownerId: "user-1",
+      }),
+    ).resolves.toEqual({
+      id: "file-1",
+      mimeType: "image/png",
+      name: "preview.png",
+    });
+  });
+
+  it("prevents lowering max downloads below the current usage", async () => {
+    const harness = createSettingsHarness({
+      initialLinkRows: [{ download_count: 3, id: "link-1" }],
+    });
+    vi.spyOn(MariadbConnection, "getConnection").mockReturnValue(harness.db as never);
+
+    await expect(
+      updateShareLinkSettings({
+        allowedEmails: ["reader@example.com"],
+        id: "link-1",
+        maxDownloads: 2,
+        ownerId: "user-1",
+      }),
+    ).rejects.toThrowError(
+      new ShareServiceError(
+        "INVALID_DOWNLOAD_LIMIT",
+        "Max downloads cannot be lower than the current download count",
+        400,
+      ),
+    );
+    expect(harness.spies.transaction).not.toHaveBeenCalled();
+  });
+});

--- a/secure-vault/tests/sharing/verify-otp-route.test.ts
+++ b/secure-vault/tests/sharing/verify-otp-route.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  createShareAccessSession: vi.fn(),
+  recordShareAccess: vi.fn(),
+  verifyOtp: vi.fn(),
+}));
+
+vi.mock("@/lib/sharing/otp-service", () => ({
+  isShareOrOtpError: (error: unknown) =>
+    Boolean(
+      error
+      && typeof error === "object"
+      && "status" in (error as Record<string, unknown>)
+      && "message" in (error as Record<string, unknown>),
+    ),
+  verifyOtp: mocks.verifyOtp,
+}));
+
+vi.mock("@/lib/sharing/share-access-session", () => ({
+  createShareAccessSession: mocks.createShareAccessSession,
+}));
+
+vi.mock("@/lib/sharing/share-service", () => ({
+  recordShareAccess: mocks.recordShareAccess,
+}));
+
+import { POST } from "@/app/api/share/[token]/verify-otp/route";
+
+function createRequest(body: unknown) {
+  return new Request("https://example.com/api/share/token/verify-otp", {
+    body: JSON.stringify(body),
+    headers: {
+      "Content-Type": "application/json",
+      "x-forwarded-for": "198.51.100.7, 198.51.100.8",
+      "user-agent": "Vitest Browser",
+    },
+    method: "POST",
+  });
+}
+
+describe("verify otp route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 400 when email or code is missing", async () => {
+    const response = await POST(createRequest({ email: "reader@example.com" }) as never, {
+      params: Promise.resolve({ token: "share-token" }),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Email and code are required",
+    });
+  });
+
+  it("creates a session and access log on success", async () => {
+    mocks.verifyOtp.mockResolvedValue({
+      email: "reader@example.com",
+      linkExpiresAt: new Date("2026-05-01T00:00:00.000Z"),
+      linkId: "link-1",
+    });
+
+    const response = await POST(
+      createRequest({ code: "123456", email: "reader@example.com" }) as never,
+      { params: Promise.resolve({ token: "share-token" }) },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ success: true });
+    expect(mocks.createShareAccessSession).toHaveBeenCalledWith({
+      email: "reader@example.com",
+      expiresAt: new Date("2026-05-01T00:00:00.000Z"),
+      linkId: "link-1",
+    });
+    expect(mocks.recordShareAccess).toHaveBeenCalledWith({
+      email: "reader@example.com",
+      ipAddress: "198.51.100.7",
+      linkId: "link-1",
+      userAgent: "Vitest Browser",
+    });
+  });
+
+  it("maps otp verification errors to their status codes", async () => {
+    mocks.verifyOtp.mockRejectedValueOnce({
+      code: "OTP_INVALID",
+      message: "Invalid verification code",
+      status: 403,
+    });
+
+    const response = await POST(
+      createRequest({ code: "000000", email: "reader@example.com" }) as never,
+      { params: Promise.resolve({ token: "share-token" }) },
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid verification code" });
+    expect(mocks.createShareAccessSession).not.toHaveBeenCalled();
+  });
+});

--- a/tasks/phase-08-link-sharing.md
+++ b/tasks/phase-08-link-sharing.md
@@ -1,121 +1,901 @@
-# Phase 8 — Link Sharing & Access Control
+# Phase 8 - Link Sharing & Access Control
 
-> **Objective:** Implement secure share links with expiry, email allowlists, OTP verification, revocation, and access logging.
+> **Objective:** Implement secure share links with expiry, email allowlists, OTP verification, revocation, download limits, and access logging in a way that fits the current Next.js + Drizzle architecture.
 
-**Depends on:** Phase 5 (Download), Phase 7 (Folders — for folder sharing), Phase 15.0 (Email service)  
-**Blueprint ref:** Section 6 (Link Sharing), Section 15 (Folder Sharing)
+**Depends on:** Phase 5 (File Download), Phase 7 (Folder System)  
+**No longer blocked by:** Phase 15.0. This phase now includes the minimal email module required for OTP delivery.  
+**Blueprint ref:** Section 6 (Link Sharing), Section 15 (Folder Sharing), Section 20 (Application-level scoping)
 
 ---
 
-## Tasks
+## Why This Plan Changed
 
-- [ ] **8.1 — Implement share link service**
-  - File: `src/lib/services/share-service.ts`
-  - `createShareLink(fileId, options)` — generates nanoid(32) token, stores in DB
-  - Options: `expiresAt`, `maxDownloads`, `isPublic`, `allowedEmails[]`
-  - `getShareLink(token)` — validates token, checks expiry/revocation
-  - `revokeShareLink(linkId)` — sets `revoked_at`
-  - `listShareLinks(fileId)` — returns all links for a file
+When this phase was audited on **2026-04-04**, the repo already had:
 
-- [ ] **8.2 — Implement OTP service**
-  - File: `src/lib/services/otp-service.ts`
-  - `generateOTP(shareLinkId, email)` — 6-digit code, hashed with SHA-256, stored in DB, 5 min TTL
-  - `verifyOTP(shareLinkId, email, code)` — hash comparison, max 3 attempts
-  - `sendOTP(email, code)` — sends via email service
+- sharing tables in `src/lib/db/schema/sharing.ts`
+- file/folder action menus in `src/components/files/*`
+- authenticated file streaming in `src/app/api/files/[id]/service.ts`
+- proxy routing that knows about `/api/share/:path*`
 
-- [ ] **8.3 — Verify email service integration** _(email service built in Phase 15.0)_
-  - Verify `src/lib/email/index.ts` has `sendOTPEmail(to, code)`
-  - The email service and HTML templates are created in Phase 15 task 15.0
-  - This phase only needs to call `sendOTPEmail()` from the OTP service
+But it did **not** yet have:
 
-- [ ] **~~8.3b~~ — Email templates** _(covered by Phase 15.0)_
-  - Templates already created in Phase 15 task 15.0 (`src/lib/email/templates.ts`)
-  - No additional work needed here
+- `sendOTPEmail()` in `src/lib/email/index.ts`
+- a public share page at `/s/[token]`
+- public share APIs
+- schema support for per-email OTP attempts
+- schema support for logging verified email on access
 
-- [ ] **8.4 — Build share link creation UI**
-  - File: `src/components/share/create-share-dialog.tsx`
-  - Form: expiry selector (1h, 24h, 7d, 30d, never), email allowlist input, max downloads, public toggle
-  - Copy link button
-  - Shows existing share links for this file
+Because of that, this phase must be self-sufficient. A junior engineer should be able to complete link sharing from this document without waiting on Phase 15.
 
-- [ ] **8.5 — Build share link viewer page**
-  - File: `src/app/s/[token]/page.tsx`
-  - Access flow per Section 6 flowchart:
-    1. Check link exists + not revoked → 404 if invalid
-    2. Check expiry → show "Link Expired" if expired
-    3. If email allowlist → prompt for email → send OTP → verify
-    4. If public → serve file directly
-  - Download/preview buttons
+---
 
-- [ ] **8.6 — Build OTP verification page**
-  - File: `src/app/s/[token]/verify/page.tsx` (or modal)
-  - Email input → OTP code input (6 digits)
-  - Shows attempts remaining
-  - Lockout after 3 failed attempts
+## Success Criteria
 
-- [ ] **8.7 — Implement access logging**
-  - On every successful share link access: insert into `share_link_access_logs`
-  - Record: IP, email (if verified), timestamp
+Phase 8 is complete when all of the following are true:
 
-- [ ] **8.8 — Implement download counter**
-  - Increment `share_links.download_count` on each download
-  - If `download_count >= max_downloads` → deny access
+1. A signed-in, verified user can create a share link for a file or folder.
+2. Public links work in an incognito browser without requiring the owner to be logged in.
+3. Restricted links can require an allowlisted email plus OTP verification.
+4. Revoked or invalid links do not leak whether a resource exists.
+5. Download limits and expiry are enforced server-side on every access.
+6. Successful access is logged with IP, user agent, and verified email when applicable.
+7. Folder shares allow safe navigation inside the shared subtree only.
 
-- [ ] **8.9 — Build share link management UI**
-  - File: `src/components/share/share-links-list.tsx`
-  - Shows all share links for a file: token (truncated), status, downloads, expiry
-  - Revoke button per link
-  - Access log viewer per link
+---
 
-- [ ] **8.10 — Extend sharing to folders**
-  - Allow `createShareLink(null, folderId, options)` — share entire folder
-  - Constraint: exactly one of `file_id` or `folder_id` must be set
-  - **Folder share viewer UI** in `/s/[token]`:
-    - Show folder name + listing of files (icon, name, size) and subfolders
-    - Subfolder navigation: clicking subfolder reloads with `?path=subfolder` query param (same share token)
-    - Individual file download button per file (no bulk ZIP for MVP)
-    - Breadcrumb navigation within the shared folder context
-    - Mobile-responsive layout
+## Scope
+
+### In scope
+
+- Public file share links
+- Public folder share links
+- Expiry
+- Download limits
+- Email allowlist
+- OTP generation and verification
+- OTP email delivery
+- Revocation
+- Access logging
+- Owner management UI for creating and revoking links
+
+### Out of scope for this phase
+
+- Bulk ZIP download for folder shares
+- Rich access-log analytics UI
+- Rate limiting beyond simple OTP attempt enforcement
+- Full password reset / verification email flows from Phase 15
+- AI-generated sharing flows
+
+---
+
+## Current Codebase Reality
+
+### Already implemented
+
+| Feature | Location |
+| --- | --- |
+| Sharing tables exist | `src/lib/db/schema/sharing.ts` |
+| Sharing relations are exported | `src/lib/db/schema/index.ts` |
+| Authenticated file streaming and FEK decryption exist | `src/app/api/files/[id]/service.ts` |
+| Authenticated download route exists | `src/app/api/files/[id]/download/route.ts` |
+| File explorer uses server actions + React Query | `src/app/(dashboard)/files/actions.ts`, `src/components/files/files-library.tsx` |
+| File and folder action menus are available integration points | `src/components/files/file-actions-menu.tsx`, `src/components/files/folder-actions-menu.tsx` |
+| Proxy matcher includes `/api/share/:path*` | `src/proxy.ts` |
+
+### Missing or incomplete
+
+| Gap | Why it matters |
+| --- | --- |
+| `share_link_otps` has no `email` column | OTPs must be tied to a specific requested email |
+| `share_link_otps` has no attempt counter | Needed for "max 3 attempts" |
+| `share_link_access_logs` has no `email` column | Required to log verified email |
+| `share_links.expires_at` is non-null | Conflicts with "never" expiry |
+| No email module exists | OTP cannot be delivered |
+| `/api/share/:path*` is currently proxy-protected | Public links would get redirected before token validation |
+| No public `/s/[token]` route exists | Main user flow is missing |
+
+---
+
+## Recommended Architecture
+
+Use a **two-lane model**:
+
+- **Owner lane**
+  - signed-in user
+  - dashboard UI
+  - server actions for create/revoke
+  - authenticated GET routes for management data
+- **Public lane**
+  - anonymous visitor
+  - `/s/[token]`
+  - public `/api/share/...` routes
+  - no session cookie required
+  - access granted purely by share token + restrictions
+
+### Key rule
+
+A share link is a **separate access model** from authenticated file ownership. Never reuse owner session requirements for public share access.
+
+### Recommended module layout
+
+| Responsibility | File |
+| --- | --- |
+| Email sending | `src/lib/email/index.ts` |
+| Email HTML templates | `src/lib/email/templates.ts` |
+| Share link business rules | `src/lib/sharing/share-service.ts` |
+| OTP business rules | `src/lib/sharing/otp-service.ts` |
+| Verified share-access cookie | `src/lib/sharing/share-access-session.ts` |
+| Share owner mutations | `src/app/(dashboard)/files/share-actions.ts` |
+| Share management read API | `src/app/api/share/links/route.ts` |
+| Public OTP routes | `src/app/api/share/[token]/request-otp/route.ts`, `src/app/api/share/[token]/verify-otp/route.ts` |
+| Public file access routes | `src/app/api/share/[token]/download/route.ts`, `src/app/api/share/[token]/preview/route.ts` |
+| Public page | `src/app/s/[token]/page.tsx` |
+| Owner UI dialog | `src/components/share/create-share-dialog.tsx` |
+| Owner UI list | `src/components/share/share-links-list.tsx` |
+
+---
+
+## Important Product Decisions
+
+These choices should be implemented exactly unless product requirements change.
+
+### Link target rules
+
+- A share link must target **exactly one** of:
+  - `file_id`
+  - `folder_id`
+- If both are missing: reject create request
+- If both are present: reject create request
+
+### Public vs restricted rules
+
+- If `allowedEmails` is empty, the link is public
+- If `allowedEmails` contains at least one email, the link is restricted
+- Do not allow a configuration that is both:
+  - `isPublic === true`
+  - `allowedEmails.length > 0`
+
+### Expiry rules
+
+- Supported choices:
+  - `1h`
+  - `24h`
+  - `7d`
+  - `30d`
+  - `never`
+- Store `expires_at = null` for "never"
+- Expiry is checked on:
+  - page view
+  - OTP request
+  - OTP verify
+  - preview
+  - download
+
+### Download counting rules
+
+- Increment `download_count` only when a real file download is authorized and about to stream
+- Do not increment on:
+  - page load
+  - preview page render
+  - OTP request
+  - OTP verification
+
+### Access logging rules
+
+- Log on successful restricted unlock
+- Log on successful preview/download access
+- Include verified email only if the visitor actually passed email verification
+
+### Folder navigation rules
+
+- Shared folder browsing must stay inside the shared root subtree
+- Use folder IDs in the `path` query value, not folder names
+- Example:
+  - `/s/abc123?path=folderA/folderB`
+- Every path segment must be validated as a descendant of the shared root
+
+---
+
+## Implementation Order
+
+Follow this order. It reduces rework and keeps public access safe.
+
+1. Build the minimal email module needed for OTP
+2. Align the sharing schema
+3. Build share and OTP services
+4. Build verified share-access cookie handling
+5. Add owner create/revoke/list flows
+6. Add public file-link page and routes
+7. Reuse the decryption/streaming pipeline for public share access
+8. Add folder sharing
+9. Add logging and finish tests
+
+---
+
+## Detailed Tasks
+
+### 8.0 - Build the minimal email module needed for OTP
+
+This phase must no longer assume Phase 15 has already created email utilities.
+
+- [ ] Create `src/lib/email/index.ts`
+  - Export `sendEmail(to, subject, html)`
+  - Export `sendOTPEmail(to, code)`
+- [ ] Create `src/lib/email/templates.ts`
+  - Export `otpEmailHtml(code)`
+- [ ] Keep this email implementation intentionally narrow
+  - only what Phase 8 needs
+  - password reset and verification templates can still arrive in Phase 15 later
+
+#### Implementation notes
+
+- Choose one provider:
+  - `Resend` is preferred if available
+  - fallback can be SMTP if the repo already standardizes on it later
+- Add environment variable notes to this phase:
+  - `RESEND_API_KEY`
+  - `EMAIL_FROM`
+- `sendEmail()` should throw a normal server error if delivery fails
+- `sendOTPEmail()` should:
+  - render `otpEmailHtml(code)`
+  - call `sendEmail()`
+
+#### Minimum template requirements
+
+- simple HTML layout
+- project name / branding
+- OTP code in large monospace text
+- short validity note: "This code expires in 5 minutes"
+- ignore-if-not-requested footer
+
+#### Why build this now
+
+Without this module, the OTP service cannot be completed or tested. Phase 15 can later extend this same module instead of replacing it.
+
+---
+
+### 8.1 - Align the sharing schema with the required behavior
+
+- [ ] Update `src/lib/db/schema/sharing.ts`
+  - make `share_links.expires_at` nullable
+  - add `email` to `share_link_otps`
+  - add `attempt_count` to `share_link_otps`
+  - add nullable `email` to `share_link_access_logs`
+  - add index on `share_links.folder_id`
+  - add uniqueness guard for allowlist emails if practical
+- [ ] Generate Drizzle migration
+- [ ] Review migration carefully before apply
+
+#### Expected table behavior
+
+##### `share_links`
+
+- `id`
+- `file_id` nullable
+- `folder_id` nullable
+- `created_by`
+- `token`
+- `expires_at` nullable
+- `max_downloads` nullable
+- `download_count`
+- `is_public`
+- `revoked_at`
+- `created_at`
+
+##### `share_link_otps`
+
+- `id`
+- `link_id`
+- `email`
+- `otp_hash`
+- `attempt_count`
+- `expires_at`
+- `used_at`
+- `created_at`
+
+##### `share_link_access_logs`
+
+- `id`
+- `link_id`
+- `ip_address`
+- `user_agent`
+- `email` nullable
+- `accessed_at`
+
+#### Service-level validations
+
+Even if MariaDB does not enforce everything with constraints, the service layer must enforce:
+
+- exactly one of `file_id` / `folder_id`
+- owner must own target
+- target must not be deleted
+
+---
+
+### 8.2 - Build the share service
+
+- [ ] Create `src/lib/sharing/share-service.ts`
+
+#### Primary responsibilities
+
+- create links
+- fetch link by token
+- list links for a file or folder owner
+- revoke links
+- validate token state
+- log access
+- increment downloads
+
+#### Recommended public functions
+
+- `createShareLink(input)`
+- `getShareLinkByToken(token)`
+- `listShareLinksForOwner(input)`
+- `revokeShareLink(input)`
+- `assertShareLinkAccessible(link)`
+- `recordShareAccess(input)`
+- `incrementDownloadCount(input)`
+
+#### `createShareLink(input)` contract
+
+Input should include:
+
+- `createdBy`
+- `fileId?`
+- `folderId?`
+- `expiresAt: Date | null`
+- `maxDownloads: number | null`
+- `allowedEmails: string[]`
+
+Behavior:
+
+- validate exactly one target
+- validate owner owns target
+- normalize emails to lowercase + trim
+- remove duplicates
+- create a `nanoid(32)` token
+- insert link row
+- insert allowlist rows
+- return:
+  - `id`
+  - `token`
+  - `url`
+  - `expiresAt`
+  - `maxDownloads`
+  - `downloadCount`
+  - `isPublic`
+  - `allowedEmails`
+
+#### `getShareLinkByToken(token)` should return enough data for both page rendering and route access
+
+Recommended shape:
+
+- link metadata
+- target type: `file` or `folder`
+- target IDs
+- owner ID
+- allowlist emails
+- revoked state
+- expiry state
+
+#### Error handling rules
+
+- invalid token -> behave like not found
+- revoked link -> behave like not found
+- expired link -> distinct expired state is acceptable on page render, but APIs should still avoid leaking target details
+
+---
+
+### 8.3 - Build the OTP service
+
+- [ ] Create `src/lib/sharing/otp-service.ts`
+
+#### Responsibilities
+
+- generate OTP
+- store hashed OTP
+- send OTP email
+- verify OTP
+- track attempts
+- mark OTP as used
+
+#### OTP rules
+
+- 6 digits
+- numeric only
+- expires in 5 minutes
+- max 3 failed attempts
+- scoped to `link_id + email`
+- old unused OTP rows for same `link_id + email` should be invalidated when a new OTP is created
+
+#### Recommended functions
+
+- `generateOtpCode()`
+- `hashOtp(code)`
+- `createAndSendOtp({ linkId, email })`
+- `verifyOtp({ linkId, email, code })`
+
+#### `createAndSendOtp({ linkId, email })`
+
+Behavior:
+
+- confirm link exists and is still active
+- confirm email is in allowlist
+- invalidate previous unused OTP rows for the same link/email
+- create new OTP row with:
+  - `attempt_count = 0`
+  - `expires_at = now + 5 minutes`
+- send email through `sendOTPEmail(email, code)`
+
+#### `verifyOtp({ linkId, email, code })`
+
+Behavior:
+
+- find latest unused OTP for `linkId + email`
+- reject if no active OTP exists
+- reject if expired
+- reject if attempts already >= 3
+- compare stored hash
+- if wrong:
+  - increment attempts
+  - reject
+- if correct:
+  - set `used_at`
+  - return success
+
+#### Recommended user-facing behavior
+
+- do not reveal allowlist contents
+- "We sent a code if this email is allowed" is safer than explicit enumeration
+- but once the visitor is already inside the restricted-link flow, a clear "This email is not allowed for this link" message is acceptable if product prefers it
+
+---
+
+### 8.4 - Build verified share-access session handling
+
+- [ ] Create `src/lib/sharing/share-access-session.ts`
+
+#### Why this is needed
+
+After OTP passes, the visitor needs a short-lived proof that they already verified access. That proof should not live only in React state, because preview/download routes run on the server.
+
+#### Recommended design
+
+- use a signed, `httpOnly` cookie
+- cookie scope should be narrow
+- cookie should include:
+  - `linkId`
+  - `email`
+  - `verifiedAt`
+  - `expiresAt`
+
+#### Recommended helper functions
+
+- `createShareAccessSession({ linkId, email })`
+- `readShareAccessSession(linkId)`
+- `clearShareAccessSession(linkId)`
+
+#### Rules
+
+- session TTL should not exceed the link expiry
+- if link expires, session becomes invalid
+- if link is revoked, session becomes invalid
+- if cookie payload is invalid or tampered, treat as no session
+
+---
+
+### 8.5 - Add owner management flows
+
+- [ ] Create `src/app/(dashboard)/files/share-actions.ts`
+- [ ] Create `src/app/api/share/links/route.ts`
+
+#### Owner mutations
+
+Implement server actions for:
+
+- `createShareLinkAction(...)`
+- `revokeShareLinkAction(...)`
+
+#### Action rules
+
+- require signed-in user
+- require verified email using `requireVerifiedUser()`
+- validate inputs
+- call share service
+- revalidate `/files`
+
+#### Owner read route
+
+`GET /api/share/links`
+
+Supported query params:
+
+- `fileId`
+- `folderId`
+
+Rules:
+
+- exactly one must be provided
+- require signed-in user
+- return only links owned by the current user for that target
+
+---
+
+### 8.6 - Update the proxy for public share access
+
+- [ ] Update `src/proxy.ts`
+
+#### Required change
+
+Remove `/api/share/:path*` from the proxy matcher.
+
+#### Why
+
+The proxy currently redirects unauthenticated requests to `/login`. Public share APIs must be reachable by anonymous users.
+
+#### Also review
+
+- `/shared/:path*` currently exists in the matcher even though the share page design uses `/s/[token]`
+- remove or rename stale matcher entries if they are no longer needed
+
+---
+
+### 8.7 - Add public share APIs
+
+- [ ] Create:
+  - `src/app/api/share/[token]/request-otp/route.ts`
+  - `src/app/api/share/[token]/verify-otp/route.ts`
+  - `src/app/api/share/[token]/download/route.ts`
+  - `src/app/api/share/[token]/preview/route.ts`
+
+#### Route contract: `POST /api/share/[token]/request-otp`
+
+Request body:
+
+```json
+{ "email": "user@example.com" }
+```
+
+Behavior:
+
+- validate token
+- reject invalid, revoked, or expired links
+- reject public links because they do not need OTP
+- normalize email
+- create and send OTP
+
+Response recommendation:
+
+- `200` with generic success message
+- avoid leaking too much detail about allowlist membership
+
+#### Route contract: `POST /api/share/[token]/verify-otp`
+
+Request body:
+
+```json
+{ "email": "user@example.com", "code": "123456" }
+```
+
+Behavior:
+
+- validate token
+- verify OTP
+- create share-access session cookie
+- log successful restricted unlock
+
+Response recommendation:
+
+- `200` with `{ success: true }`
+
+#### Route contract: `GET /api/share/[token]/download`
+
+Behavior:
+
+- validate token
+- check expiry/revocation
+- check target exists
+- check download limit
+- if restricted link, require valid share-access session cookie
+- stream file
+- increment download count
+- log access
+
+#### Route contract: `GET /api/share/[token]/preview`
+
+Same as download, except:
+
+- set inline disposition
+- only allow previewable MIME types
+
+---
+
+### 8.8 - Reuse the existing decryption/streaming pipeline
+
+- [ ] Refactor `src/app/api/files/[id]/service.ts`
+
+#### Goal
+
+Do not duplicate the chunk decryption logic.
+
+#### Recommended refactor
+
+Split the existing service into:
+
+- low-level file-stream preparation logic
+- owner-auth wrapper for current authenticated routes
+- share-link wrapper for public routes
+
+#### Public share stream flow
+
+1. Resolve share link from token
+2. Resolve target file
+3. Load owner user record
+4. Decrypt owner's UEK
+5. Use existing FEK + chunk metadata flow
+6. Stream response
+
+#### Important note for a junior engineer
+
+The public visitor does **not** have the owner's session. That is okay. The server can still decrypt the owner's UEK from the database because that is how the app already handles server-side file access.
+
+---
+
+### 8.9 - Build the owner-facing share UI
+
+- [ ] Add "Share" entry point to:
+  - `src/components/files/file-actions-menu.tsx`
+  - `src/components/files/folder-actions-menu.tsx`
+- [ ] Create `src/components/share/create-share-dialog.tsx`
+- [ ] Create `src/components/share/share-links-list.tsx`
+
+#### Dialog requirements
+
+Inputs:
+
+- expiry selector
+- max downloads
+- allowlist emails
+- public/restricted selection
+
+Outputs:
+
+- newly created public URL
+- copy button
+- current list of existing links for this target
+
+#### Validation rules
+
+- max downloads must be positive integer or empty
+- emails must be normalized
+- duplicate emails removed
+- if allowlist has emails, disable or override the public toggle
+
+#### Existing links list should show
+
+- target type
+- created date
+- expiry
+- revoked status
+- downloads used / max
+- restricted vs public
+- revoke button
+
+---
+
+### 8.10 - Build the public page at `/s/[token]`
+
+- [ ] Create `src/app/s/[token]/page.tsx`
+
+#### Page states
+
+The page should render one of these states:
+
+1. invalid or revoked -> `notFound()`
+2. expired -> expired message page
+3. restricted and not yet verified -> email + OTP flow
+4. valid file share -> preview/download UI
+5. valid folder share -> folder listing UI
+
+#### Recommended page structure
+
+- top-level share header
+- status card for invalid/expired
+- restricted access panel
+- file viewer panel
+- folder browser panel
+
+#### Keep the OTP flow on the same page for MVP
+
+Recommended interaction:
+
+- visitor enters email
+- app calls `request-otp`
+- app shows code input
+- visitor enters code
+- app calls `verify-otp`
+- page refreshes or refetches state
+- protected content becomes visible
+
+Using one page is simpler than splitting into `/verify`.
+
+---
+
+### 8.11 - Add folder sharing
+
+- [ ] Extend share service to support folder targets
+- [ ] Reuse the same public page and public routes
+
+#### Folder page requirements
+
+- show current folder name
+- show subfolders
+- show files
+- show breadcrumb
+- allow navigation deeper
+- allow per-file preview/download
+- mobile friendly layout
+
+#### Required query behavior
+
+Recommended URL:
+
+```text
+/s/[token]?path=folderA/folderB
+```
+
+Where each path segment is a **folder ID** relative to the shared root.
+
+#### Validation steps for `path`
+
+1. Start with the shared root folder
+2. For each folder ID in `path`
+3. Confirm that folder exists
+4. Confirm its parent chain stays inside the shared subtree
+5. If any step fails, return not found or access denied state
+
+#### Important simplification for MVP
+
+- no ZIP download
+- no recursive bulk download
+- only per-file actions
+
+---
+
+### 8.12 - Implement access logging and counters
+
+- [ ] Add access logging to successful flows
+- [ ] Increment download count for successful downloads
+
+#### Log on these events
+
+- successful restricted unlock
+- successful preview
+- successful download
+
+#### Logged data
+
+- `link_id`
+- `ip_address`
+- `user_agent`
+- `email` when verified
+- `accessed_at`
+
+#### Counter logic
+
+Before streaming:
+
+- if `max_downloads` is null -> allow
+- if `download_count < max_downloads` -> allow
+- otherwise reject
+
+After authorization and before stream response:
+
+- increment `download_count`
+
+---
+
+## Error Handling Rules
+
+Keep behavior consistent so users understand what happened and attackers learn as little as possible.
+
+| Scenario | Recommended behavior |
+| --- | --- |
+| Random token | `404` |
+| Revoked token | `404` |
+| Expired token on page | friendly expired page |
+| Expired token on API access | `410` or `403`, but do not leak target details |
+| Wrong OTP | show invalid code message |
+| OTP expired | show expired code message and allow resend |
+| OTP attempts exceeded | show locked message and require new OTP |
+| Download limit reached | blocked message |
+| Folder path escape attempt | `404` |
 
 ---
 
 ## Deliverables
 
-| Output            | Location                                       |
-| ----------------- | ---------------------------------------------- |
-| Share service     | `src/lib/services/share-service.ts`            |
-| OTP service       | `src/lib/services/otp-service.ts`              |
-| Email service     | `src/lib/email/index.ts`                       |
-| Share dialog      | `src/components/share/create-share-dialog.tsx` |
-| Share viewer page | `src/app/s/[token]/page.tsx`                   |
-| Share links list  | `src/components/share/share-links-list.tsx`    |
+| Output | Location |
+| --- | --- |
+| Email sender | `src/lib/email/index.ts` |
+| Email template | `src/lib/email/templates.ts` |
+| Sharing schema updates | `src/lib/db/schema/sharing.ts` |
+| Share service | `src/lib/sharing/share-service.ts` |
+| OTP service | `src/lib/sharing/otp-service.ts` |
+| Share-access session helper | `src/lib/sharing/share-access-session.ts` |
+| Share actions | `src/app/(dashboard)/files/share-actions.ts` |
+| Share links API | `src/app/api/share/links/route.ts` |
+| Public OTP APIs | `src/app/api/share/[token]/request-otp/route.ts`, `src/app/api/share/[token]/verify-otp/route.ts` |
+| Public file APIs | `src/app/api/share/[token]/download/route.ts`, `src/app/api/share/[token]/preview/route.ts` |
+| Share dialog | `src/components/share/create-share-dialog.tsx` |
+| Share links list | `src/components/share/share-links-list.tsx` |
+| Public share page | `src/app/s/[token]/page.tsx` |
 
 ---
 
-## Testing
+## Testing Plan
 
-### Automated (Vitest)
+### Automated
 
 ```bash
 npx vitest run tests/sharing
 ```
 
-| Test                                                   | Expected              |
-| ------------------------------------------------------ | --------------------- |
-| Create share link → access with valid token            | Returns file          |
-| Access expired link                                    | Returns 410 (expired) |
-| Access revoked link                                    | Returns 404           |
-| Access with email allowlist, correct email + valid OTP | Succeeds              |
-| OTP wrong code 3 times                                 | Locked out            |
-| OTP expired (> 5 min)                                  | Returns 401           |
-| Download count exceeds max                             | Returns 403           |
-| Access log recorded on each access                     | DB row exists         |
-| Token enumeration: random token → 404                  | No info leakage       |
+Recommended test files:
 
-### Manual Verification
+- `tests/sharing/email.test.ts`
+- `tests/sharing/share-service.test.ts`
+- `tests/sharing/otp-service.test.ts`
+- `tests/sharing/share-routes.test.ts`
+- `tests/sharing/share-page.test.tsx`
+- `tests/auth/proxy.test.ts`
 
-1. Upload file → Share → create public link → open in incognito → verify file loads
-2. Create link with 1h expiry → verify it works now
-3. Create link with email allowlist → enter email → receive OTP → verify access
-4. Create link → revoke it → verify incognito access returns 404
-5. Create link with max 2 downloads → download twice → third attempt blocked
+### Minimum automated coverage
+
+| Test | Expected |
+| --- | --- |
+| Create public file share | link created |
+| Create restricted file share | allowlist stored |
+| Create folder share | folder link created |
+| Reject invalid create with both target IDs | validation error |
+| Request OTP for allowed email | OTP stored, email sender called |
+| Wrong OTP increments attempts | attempts increase |
+| Wrong OTP 3 times | locked |
+| Expired OTP | rejected |
+| Correct OTP | success + access session cookie created |
+| Public file download with valid token | streams bytes |
+| Restricted file download without cookie | denied |
+| Restricted file download after OTP | succeeds |
+| Expired share link | blocked |
+| Revoked share link | `404` |
+| Download limit reached | blocked |
+| Folder share path outside subtree | blocked |
+| Access log created on success | DB row exists |
+| Proxy no longer protects public share API | matcher updated |
+
+### Manual verification
+
+1. Create a public file link and open it in an incognito window.
+2. Create a restricted file link, request OTP, and verify it unlocks correctly.
+3. Enter a wrong OTP three times and confirm the current OTP becomes unusable.
+4. Revoke a link and confirm the public URL now fails.
+5. Create a download-limited link and confirm the final allowed download works while the next one fails.
+6. Share a folder, navigate into a nested subfolder, and confirm navigation never escapes the shared root.
+
+---
+
+## Notes for Future Phase 15 Work
+
+Phase 15 should **reuse** the email module introduced here, not replace it.
+
+When Phase 15 begins:
+
+- keep `src/lib/email/index.ts`
+- keep `src/lib/email/templates.ts`
+- add:
+  - `sendPasswordResetEmail()`
+  - `sendVerificationEmail()`
+  - `resetEmailHtml()`
+  - `verifyEmailHtml()`
+
+That keeps Phase 8 and Phase 15 aligned instead of creating two competing email implementations.


### PR DESCRIPTION
## Summary
- implement and harden Phase 8 secure link sharing
- add owner link management improvements for restricted/public links
- expand unit, route, and Playwright coverage for share flows and edge cases

## Testing
- `npx tsc --noEmit`
- sharing unit and route tests
- Playwright share flows and regressions

closes #12
